### PR TITLE
Expose more API and implement trivia for XmlElementSyntax

### DIFF
--- a/src/Microsoft.Language.Xml.Tests/Microsoft.Language.Xml.Tests.csproj
+++ b/src/Microsoft.Language.Xml.Tests/Microsoft.Language.Xml.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.extensibility.core" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -20,5 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestXml.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <XunitTest_Xml Include="$(OutputPath)\TestResult.xml" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Language.Xml.Tests/TestTrivia.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestTrivia.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Language.Xml.Test
+{
+    public class TestTrivia
+    {
+        const string ThreeSpaces = "   ";
+        const string XmlElementWithAttributeAndContent = "<foo attribute=\"value\">content</foo>";
+
+        [Fact]
+        public void TestXmlElementSyntaxLeadingTrivia()
+        {
+            var element = GetElementSyntax(XmlElementWithAttributeAndContent);
+            var elementWithTrivia = element.WithLeadingTrivia(SyntaxFactory.WhitespaceTrivia(ThreeSpaces));
+            Assert.IsType<XmlElementSyntax>(elementWithTrivia);
+            Assert.StartsWith(ThreeSpaces, elementWithTrivia.ToFullString());
+        }
+
+        [Fact]
+        public void TestXmlElementSyntaxTrailingTrivia()
+        {
+            var element = GetElementSyntax(XmlElementWithAttributeAndContent);
+            var elementWithTrivia = element.WithTrailingTrivia(SyntaxFactory.WhitespaceTrivia(ThreeSpaces));
+            Assert.IsType<XmlElementSyntax>(elementWithTrivia);
+            Assert.EndsWith(ThreeSpaces, elementWithTrivia.ToFullString());
+        }
+
+        static XmlElementSyntax GetElementSyntax(string xml) => Parser.ParseText(xml).RootSyntax as XmlElementSyntax;
+    }
+}

--- a/src/Microsoft.Language.Xml/Syntax/SkippedTokensTriviaSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SkippedTokensTriviaSyntax.cs
@@ -24,7 +24,7 @@
             throw null;
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitSkippedTokensTrivia(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxFactory.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxFactory.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Language.Xml
             return new XmlElementStartTagSyntax(SyntaxKind.XmlElementStartTag, lessThanToken, name, attributes, greaterThanToken);
         }
 
-        internal static XmlElementEndTagSyntax XmlElementEndTag(PunctuationSyntax lessThanSlashToken, XmlNameSyntax name, PunctuationSyntax greaterThanToken)
+        public static XmlElementEndTagSyntax XmlElementEndTag(PunctuationSyntax lessThanSlashToken, XmlNameSyntax name, PunctuationSyntax greaterThanToken)
         {
             Debug.Assert(lessThanSlashToken != null && lessThanSlashToken.Kind == SyntaxKind.LessThanSlashToken);
             Debug.Assert(greaterThanToken != null && greaterThanToken.Kind == SyntaxKind.GreaterThanToken);
@@ -127,7 +127,7 @@ namespace Microsoft.Language.Xml
         ''' Represents an empty XML element of the form &lt;element /&gt;
         ''' </summary>
         */
-        internal static XmlEmptyElementSyntax XmlEmptyElement(
+        public static XmlEmptyElementSyntax XmlEmptyElement(
             PunctuationSyntax lessThanToken,
             XmlNameSyntax name,
             SyntaxList<SyntaxNode> attributes,
@@ -144,7 +144,7 @@ namespace Microsoft.Language.Xml
         ''' element.
         ''' </summary>
         */
-        internal static XmlStringSyntax XmlString(PunctuationSyntax startQuoteToken, SyntaxList<XmlTextTokenSyntax> textTokens, PunctuationSyntax endQuoteToken)
+        public static XmlStringSyntax XmlString(PunctuationSyntax startQuoteToken, SyntaxList<XmlTextTokenSyntax> textTokens, PunctuationSyntax endQuoteToken)
         {
             //Debug.Assert(startQuoteToken != null && SyntaxFacts.IsXmlStringStartQuoteToken(startQuoteToken.Kind));
             //Debug.Assert(endQuoteToken != null && SyntaxFacts.IsXmlStringEndQuoteToken(endQuoteToken.Kind));
@@ -159,7 +159,7 @@ namespace Microsoft.Language.Xml
         ''' whitespace in an XML literal expression.
         ''' </summary>
         */
-        internal static XmlDeclarationOptionSyntax XmlDeclarationOption(XmlNameTokenSyntax name, PunctuationSyntax equals, XmlStringSyntax value)
+        public static XmlDeclarationOptionSyntax XmlDeclarationOption(XmlNameTokenSyntax name, PunctuationSyntax equals, XmlStringSyntax value)
         {
             Debug.Assert(name != null && name.Kind == SyntaxKind.XmlNameToken);
             Debug.Assert(equals != null && equals.Kind == SyntaxKind.EqualsToken);
@@ -184,7 +184,7 @@ namespace Microsoft.Language.Xml
         ''' Represents the XML declaration prologue in an XML literal expression.
         ''' </summary>
         */
-        internal static XmlDeclarationSyntax XmlDeclaration(PunctuationSyntax lessThanQuestionToken, SyntaxToken xmlKeyword, XmlDeclarationOptionSyntax version, XmlDeclarationOptionSyntax encoding, XmlDeclarationOptionSyntax standalone, PunctuationSyntax questionGreaterThanToken)
+        public static XmlDeclarationSyntax XmlDeclaration(PunctuationSyntax lessThanQuestionToken, SyntaxToken xmlKeyword, XmlDeclarationOptionSyntax version, XmlDeclarationOptionSyntax encoding, XmlDeclarationOptionSyntax standalone, PunctuationSyntax questionGreaterThanToken)
         {
             Debug.Assert(lessThanQuestionToken != null && lessThanQuestionToken.Kind == SyntaxKind.LessThanQuestionToken);
             //Debug.Assert(xmlKeyword != null && xmlKeyword.Kind == SyntaxKind.XmlKeyword);
@@ -203,7 +203,7 @@ namespace Microsoft.Language.Xml
             return new XmlPrefixSyntax(localName, colon);
         }
 
-        internal static XmlProcessingInstructionSyntax XmlProcessingInstruction(
+        public static XmlProcessingInstructionSyntax XmlProcessingInstruction(
             PunctuationSyntax beginProcessingInstruction,
             XmlNameTokenSyntax name,
             SyntaxList<SyntaxNode> toList,
@@ -212,7 +212,7 @@ namespace Microsoft.Language.Xml
             return new XmlProcessingInstructionSyntax(beginProcessingInstruction, name, toList, endProcessingInstruction);
         }
 
-        internal static XmlTextTokenSyntax XmlTextLiteralToken(string text, string value, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
+        public static XmlTextTokenSyntax XmlTextLiteralToken(string text, string value, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
         {
             return new XmlTextTokenSyntax(SyntaxKind.XmlTextLiteralToken, text, leadingTrivia, trailingTrivia, value);
         }
@@ -226,24 +226,24 @@ namespace Microsoft.Language.Xml
           ''' The actual text of this token.
           ''' </param>
         */
-        internal static XmlTextTokenSyntax XmlEntityLiteralToken(string text, string value, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
+        public static XmlTextTokenSyntax XmlEntityLiteralToken(string text, string value, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
         {
             Debug.Assert(text != null);
             return new XmlTextTokenSyntax(SyntaxKind.XmlEntityLiteralToken, text, leadingTrivia, trailingTrivia, value);
         }
 
-        internal static SyntaxNode WhitespaceTrivia(string text)
+        public static SyntaxTrivia WhitespaceTrivia(string text)
         {
             Debug.Assert(text != null);
             return new SyntaxTrivia(SyntaxKind.WhitespaceTrivia, text);
         }
 
-        internal static SyntaxTrivia EndOfLineTrivia(string text)
+        public static SyntaxTrivia EndOfLineTrivia(string text)
         {
             return new SyntaxTrivia(SyntaxKind.EndOfLineTrivia, text);
         }
 
-        internal static XmlCDataSectionSyntax XmlCDataSection(
+        public static XmlCDataSectionSyntax XmlCDataSection(
             PunctuationSyntax beginCData,
             SyntaxList<XmlTextTokenSyntax> result,
             PunctuationSyntax endCData)
@@ -251,7 +251,7 @@ namespace Microsoft.Language.Xml
             return new XmlCDataSectionSyntax(SyntaxKind.XmlCDataSection, beginCData, result.Node, endCData);
         }
 
-        internal static XmlNodeSyntax XmlComment(
+        public static XmlNodeSyntax XmlComment(
             PunctuationSyntax beginComment,
             SyntaxList<XmlTextTokenSyntax> result,
             PunctuationSyntax endComment)

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxList.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxList.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Language.Xml
             return List(array);
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.Visit(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxNode.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxNode.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Language.Xml
             return GetSlot(index);
         }
 
-        internal abstract SyntaxNode Accept(SyntaxVisitor visitor);
+        public abstract SyntaxNode Accept(SyntaxVisitor visitor);
 
         private struct ComputeFullWidthState
         {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Language.Xml
 {
-    internal class SyntaxRewriter : SyntaxVisitor
+    public class SyntaxRewriter : SyntaxVisitor
     {
         public SyntaxList<TNode> VisitList<TNode>(SyntaxList<TNode> list) where TNode : SyntaxNode
         {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Language.Xml
             tokenListBuilder.Add(this);
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitSyntaxToken(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Language.Xml
             this._text = text;
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitSyntaxTrivia(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace Microsoft.Language.Xml
 {
-    internal partial class SyntaxTrivia : SyntaxNode
+    public partial class SyntaxTrivia : SyntaxNode
     {
         private readonly string _text;
         internal SyntaxTrivia(SyntaxKind kind, string text) : base(kind)

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxVisitor.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxVisitor.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Language.Xml
 {
-    internal abstract partial class SyntaxVisitor
+    public abstract partial class SyntaxVisitor
     {
         public virtual SyntaxNode Visit(SyntaxNode node)
         {

--- a/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
@@ -67,7 +67,7 @@
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlAttribute(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlCDataSectionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlCDataSectionSyntax.cs
@@ -33,7 +33,7 @@
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlCDataSection(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlCommentSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlCommentSyntax.cs
@@ -29,7 +29,7 @@
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlComment(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlDeclarationOptionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDeclarationOptionSyntax.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlDeclarationOption(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlDeclarationSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDeclarationSyntax.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlDeclaration(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlDocumentSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDocumentSyntax.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlDocument(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlElementEndTag(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
@@ -45,5 +45,21 @@ namespace Microsoft.Language.Xml
                 return NameNode.Name;
             }
         }
+
+        public override SyntaxNode WithLeadingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementEndTagSyntax(Kind,
+                                              (PunctuationSyntax)LessThanSlashToken.WithLeadingTrivia(trivia),
+                                              NameNode,
+                                              GreaterThanToken);
+        }
+
+        public override SyntaxNode WithTrailingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementEndTagSyntax(Kind,
+                                              LessThanSlashToken,
+                                              NameNode,
+                                              (PunctuationSyntax)GreaterThanToken.WithTrailingTrivia(trivia));
+        }
     }
 }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlElementStartTag(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
@@ -54,5 +54,23 @@ namespace Microsoft.Language.Xml
                 return NameNode.Name;
             }
         }
+
+        public override SyntaxNode WithLeadingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementStartTagSyntax(Kind,
+                                                (PunctuationSyntax)LessThanToken.WithLeadingTrivia(trivia),
+                                                NameNode,
+                                                Attributes,
+                                                GreaterThanToken);
+        }
+
+        public override SyntaxNode WithTrailingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementStartTagSyntax(Kind,
+                                                LessThanToken,
+                                                NameNode,
+                                                Attributes,
+                                                (PunctuationSyntax)GreaterThanToken.WithTrailingTrivia(trivia));
+        }
     }
 }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
@@ -52,5 +52,19 @@ namespace Microsoft.Language.Xml
                 return Enumerable.Empty<IXmlElementSyntax>();
             }
         }
+
+        public override SyntaxNode WithLeadingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementSyntax((XmlElementStartTagSyntax)StartTag.WithLeadingTrivia(trivia),
+                                        Content,
+                                        EndTag);
+        }
+
+        public override SyntaxNode WithTrailingTrivia(SyntaxNode trivia)
+        {
+            return new XmlElementSyntax(StartTag,
+                                        Content,
+                                        (XmlElementEndTagSyntax)EndTag.WithTrailingTrivia(trivia));
+        }
     }
 }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlElement(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlEmptyElement(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlNameSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlNameSyntax.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Language.Xml
             throw new InvalidOperationException();
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlName(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlNodeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlNodeSyntax.cs
@@ -6,7 +6,7 @@
         {
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlNode(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlPrefixSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlPrefixSyntax.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Language.Xml
             throw new InvalidOperationException();
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+	public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlPrefix(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlProcessingInstructionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlProcessingInstructionSyntax.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlProcessingInstruction(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlStringSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlStringSyntax.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlString(this);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlTextSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlTextSyntax.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Language.Xml
             throw new InvalidOperationException();
         }
 
-        internal override SyntaxNode Accept(SyntaxVisitor visitor)
+        public override SyntaxNode Accept(SyntaxVisitor visitor)
         {
             return visitor.VisitXmlText(this);
         }


### PR DESCRIPTION
This PR exposes the two following APIs:

- All of `SyntaxFactory` so that every syntax nodes can be created (e.g. `SyntaxTrivia` nodes that couldn't be created before).
- The `SyntaxVisitor`/`SyntaxRewriter` classes (and associated plumbing) to be able to easily alter XML trees.

It also adds support for adding leading/trailing trivia on XmlElementSyntax nodes by deferring to their appropriate leaf tokens.