### PR TITLE
Hard-code CRLF as "\r\n".

### DIFF
--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -2185,7 +2185,7 @@ namespace Microsoft.Language.Xml
             return MakeEndOfLineTrivia(GetNextChar());
         }
 
-        private static readonly SyntaxTrivia _crLfTrivia = SyntaxFactory.EndOfLineTrivia(Environment.NewLine);
+        private static readonly SyntaxTrivia _crLfTrivia = SyntaxFactory.EndOfLineTrivia("\r\n");
 
         private SyntaxTrivia MakeEndOfLineTriviaCRLF()
         {


### PR DESCRIPTION
Previously the parser used `Environment.NewLine` but this causes portability issues because on non-Windows systems that's `\n` (instead of `\r\n`), leading to different calculations of absolute position within the source text.

Fixes KirillOsenkov/XmlParser#11.