### PR TITLE
Added extension method to return a new IXmlElementSyntax instance

### DIFF
--- a/src/Microsoft.Language.Xml.Tests/TestModification.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestModification.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Language.Xml.Tests
@@ -12,6 +12,15 @@ namespace Microsoft.Language.Xml.Tests
             var content = Parser.ParseText ("<b />")?.RootSyntax;
             root = root.WithContent (SyntaxFactory.SingletonList (content.AsNode));
             Assert.Equal("<a><b /></a>", root.ToFullString());
+        }
+
+        [Fact]
+        public void TestElementWithAttributeAndContent()
+        {
+            var root = Parser.ParseText("<a b=\"c\"/>")?.RootSyntax;
+            var content = Parser.ParseText("<d />")?.RootSyntax;
+            root = root.WithContent(SyntaxFactory.SingletonList(content.AsNode));
+            Assert.Equal("<a b=\"c\"><d /></a >", root.ToFullString());
         }
     }
 }

--- a/src/Microsoft.Language.Xml/XmlExtensions.cs
+++ b/src/Microsoft.Language.Xml/XmlExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Language.Xml
@@ -18,6 +18,19 @@ namespace Microsoft.Language.Xml
             if (element.Content.Count == 1 && element.Content.First() is XmlCDataSectionSyntax cdata)
                 return cdata.TextTokens.ToFullString();
             return element.AsElement.Value;
+        }
+
+        /// <summary>
+        /// Return a new <see cref="IXmlElementSyntax"/> instance with
+        /// the supplied string prefix.
+        /// </summary>
+        public static IXmlElementSyntax WithPrefixName(this IXmlElementSyntax element, string prefixName)
+        {
+            var existingName = element.NameNode;
+            var existingPrefix = existingName.PrefixNode;
+            var newName = SyntaxFactory.XmlNameToken(prefixName, null, null);
+
+            return element.WithName(existingName.WithPrefix(existingPrefix.WithName(newName)));
         }
 
         /// <summary>


### PR DESCRIPTION
Added extension method to return a new IXmlElementSyntax instance with the supplied string prefix.

- The  new instance does not carry over any leading or trailing trivia from the existing element's XmlName node.