### PR TITLE
fix: Comment with whitespace Identification

### DIFF
--- a/src/Microsoft.Language.Xml.Tests/TestClassifier.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestClassifier.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -143,6 +143,28 @@ namespace Microsoft.Language.Xml.Tests
         }
 
         [Fact]
+        public void ClassifyWindow5()
+        {
+            const string xml =
+@"<WhitespaceOptInControl> 
+	<!-- X --> 
+	</WhitespaceOptInControl>";
+            int len = xml.Length;
+            T(xml, 0, len,
+                XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlName,
+                XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlText,
+                XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlComment,
+                XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlName,
+                XmlClassificationTypes.XmlDelimiter
+            );
+        }
+
+        [Fact]
         public void ClassifyAllInOne()
         {
             T(TestParser.allXml,
@@ -216,6 +238,7 @@ namespace Microsoft.Language.Xml.Tests
                 XmlClassificationTypes.XmlDelimiter,
                 XmlClassificationTypes.XmlName,
                 XmlClassificationTypes.XmlDelimiter,
+                XmlClassificationTypes.XmlText,
                 XmlClassificationTypes.XmlDelimiter,
                 XmlClassificationTypes.XmlComment,
                 XmlClassificationTypes.XmlDelimiter,

--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -1374,7 +1374,11 @@ namespace Microsoft.Language.Xml
                         InternalSyntax.SyntaxList<GreenNode> precedingTrivia = null;
                         if (Here != 0)
                         {
-                            if (!IsAllWhitespace)
+                            var isCommentContent = (CanGetCharAtOffset(Here + 1) && PeekAheadChar(Here + 1) == '!'
+                                    && CanGetCharAtOffset(Here + 2) && PeekAheadChar(Here + 2) == '-'
+                                    && CanGetCharAtOffset(Here + 3) && PeekAheadChar(Here + 3) == '-');
+
+                            if (!IsAllWhitespace || isCommentContent)
                             {
                                 return XmlMakeTextLiteralToken(null, Here, scratch);
                             }


### PR DESCRIPTION
The parser does not identify comments that begin with a space after `<--`.