### PR TITLE
feat: 2.2.12 [XML] Section 3.3.3, Attribute-Value Normalization

### DIFF
--- a/src/Microsoft.Language.Xml.Tests/TestApi.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestApi.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Language.Xml.Tests
         public void TestAttributeValueNormalization()
         {
             const string AllWhitespace = " \n\t";
-            var xml = $"<ContentControl Content=\"{AllWhitespace}X{AllWhitespace}\" />";
+            var xml = $"<A B=\"{AllWhitespace}X{AllWhitespace}\" />";
             var root = Parser.ParseText(xml)?.RootSyntax;
 
-            var attributeValue = root.Attributes.First().NormalizedValue;
+            var attributeValue = root.Attributes.First().Value;
             Assert.Equal("   X   ", attributeValue);
         }
 

--- a/src/Microsoft.Language.Xml.Tests/TestApi.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestApi.cs
@@ -13,6 +13,21 @@ namespace Microsoft.Language.Xml.Tests
             Assert.Equal("", attributeValue);
         }
 
+        /// <summary>
+        /// 2.2.12 [XML] Section 3.3.3, Attribute-Value Normalization
+        /// <seealso href="https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae" />
+        /// </summary>
+        [Fact]
+        public void TestAttributeValueNormalization()
+        {
+            const string AllWhitespace = " \n\t";
+            var xml = $"<ContentControl Content=\"{AllWhitespace}X{AllWhitespace}\" />";
+            var root = Parser.ParseText(xml)?.RootSyntax;
+
+            var attributeValue = root.Attributes.First().Value;
+            Assert.Equal("   X   ", attributeValue);
+        }
+
         [Fact]
         public void TestContent()
         {

--- a/src/Microsoft.Language.Xml.Tests/TestApi.cs
+++ b/src/Microsoft.Language.Xml.Tests/TestApi.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Language.Xml.Tests
@@ -24,7 +24,7 @@ namespace Microsoft.Language.Xml.Tests
             var xml = $"<ContentControl Content=\"{AllWhitespace}X{AllWhitespace}\" />";
             var root = Parser.ParseText(xml)?.RootSyntax;
 
-            var attributeValue = root.Attributes.First().Value;
+            var attributeValue = root.Attributes.First().NormalizedValue;
             Assert.Equal("   X   ", attributeValue);
         }
 

--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -358,8 +358,7 @@ namespace Microsoft.Language.Xml
                     case UCH_LF:
                         Here = SkipLineBreak(c, Here);
                         scratch.Append(UCH_SPACE);
-                        result = XmlMakeAttributeDataToken(precedingTrivia, Here, scratch);
-                        goto CleanUp;
+                        break;
                     case UCH_TAB:
                         scratch.Append(UCH_SPACE);
                         Here += 1;
@@ -376,7 +375,7 @@ namespace Microsoft.Language.Xml
                             var data = MissingToken(null, SyntaxKind.SingleQuoteToken);
                             if (precedingTrivia.Count > 0)
                             {
-                                data = (SyntaxToken.Green)data.WithLeadingTrivia(precedingTrivia.ToListNode());
+                                data = data.WithLeadingTrivia(precedingTrivia.ToListNode());
                             }
 
                             var errInfo = ErrorFactory.ErrorInfo(isSingle ? ERRID.ERR_ExpectedSQuote : ERRID.ERR_ExpectedQuote);
@@ -446,7 +445,7 @@ namespace Microsoft.Language.Xml
 
         private XmlTextTokenSyntax.Green XmlMakeAttributeDataToken(InternalSyntax.SyntaxList<GreenNode> precedingTrivia, int tokenWidth, StringBuilder scratch)
         {
-            return XmlMakeTextLiteralToken(precedingTrivia, tokenWidth, scratch);
+            return XmlMakeAttributeTextLiteralToken(precedingTrivia, tokenWidth, scratch);
         }
 
         private SyntaxToken.Green ScanXmlStringDouble()
@@ -1331,6 +1330,15 @@ namespace Microsoft.Language.Xml
             var value = _stringTable.Add(Scratch);
             Scratch.Clear();
             return XmlTextToken(text, precedingTrivia.Node, null);
+        }
+
+        private XmlTextTokenSyntax.Green XmlMakeAttributeTextLiteralToken(InternalSyntax.SyntaxList<GreenNode> precedingTrivia, int TokenWidth, StringBuilder Scratch)
+        {
+            Debug.Assert(TokenWidth > 0);
+            _ = GetText(TokenWidth);
+            var value = _stringTable.Add(Scratch);
+            Scratch.Clear();
+            return XmlTextToken(value, precedingTrivia.Node, null);
         }
 
         internal SyntaxToken.Green ScanXmlContent()

--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -358,7 +358,8 @@ namespace Microsoft.Language.Xml
                     case UCH_LF:
                         Here = SkipLineBreak(c, Here);
                         scratch.Append(UCH_SPACE);
-                        break;
+                        result = XmlMakeAttributeDataToken(precedingTrivia, Here, scratch);
+                        goto CleanUp;
                     case UCH_TAB:
                         scratch.Append(UCH_SPACE);
                         Here += 1;
@@ -445,7 +446,7 @@ namespace Microsoft.Language.Xml
 
         private XmlTextTokenSyntax.Green XmlMakeAttributeDataToken(InternalSyntax.SyntaxList<GreenNode> precedingTrivia, int tokenWidth, StringBuilder scratch)
         {
-            return XmlMakeAttributeTextLiteralToken(precedingTrivia, tokenWidth, scratch);
+            return XmlMakeTextLiteralToken(precedingTrivia, tokenWidth, scratch);
         }
 
         private SyntaxToken.Green ScanXmlStringDouble()
@@ -1330,15 +1331,6 @@ namespace Microsoft.Language.Xml
             var value = _stringTable.Add(Scratch);
             Scratch.Clear();
             return XmlTextToken(text, precedingTrivia.Node, null);
-        }
-
-        private XmlTextTokenSyntax.Green XmlMakeAttributeTextLiteralToken(InternalSyntax.SyntaxList<GreenNode> precedingTrivia, int TokenWidth, StringBuilder Scratch)
-        {
-            Debug.Assert(TokenWidth > 0);
-            _ = GetText(TokenWidth);
-            var value = _stringTable.Add(Scratch);
-            Scratch.Clear();
-            return XmlTextToken(value, precedingTrivia.Node, null);
         }
 
         internal SyntaxToken.Green ScanXmlContent()

--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -376,7 +376,7 @@ namespace Microsoft.Language.Xml
                             var data = MissingToken(null, SyntaxKind.SingleQuoteToken);
                             if (precedingTrivia.Count > 0)
                             {
-                                data = data.WithLeadingTrivia(precedingTrivia.ToListNode());
+                                data = (SyntaxToken.Green)data.WithLeadingTrivia(precedingTrivia.ToListNode());
                             }
 
                             var errInfo = ErrorFactory.ErrorInfo(isSingle ? ERRID.ERR_ExpectedSQuote : ERRID.ERR_ExpectedQuote);

--- a/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 
 namespace Microsoft.Language.Xml
 {
+    using System.IO;
+    using System.Text;
     using InternalSyntax;
 
     public class XmlAttributeSyntax : XmlNodeSyntax, INamedXmlNode
@@ -96,7 +98,7 @@ namespace Microsoft.Language.Xml
                     return null;
                 }
 
-                var xmlString = ValueNode as XmlStringSyntax;
+                var xmlString = ValueNode;
                 if (xmlString == null)
                 {
                     return null;
@@ -110,6 +112,14 @@ namespace Microsoft.Language.Xml
                 return xmlString.TextTokens.Node.ToFullString();
             }
         }
+
+        /// <summary>
+        /// Get Normalized <see cref="Value"/> of <see cref="XmlStringSyntax"/>
+        /// </summary>
+        /// <remarks>
+        /// Spec <seealso href="https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae">2.2.12 [XML] Section 3.3.3</seealso/>
+        /// </remarks>
+        public string NormalizedValue => Value.Replace("\r", " ").Replace("\n", " ").Replace("\t", " ");
 
         public override SyntaxNode Accept(SyntaxVisitor visitor)
         {

--- a/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
@@ -1,8 +1,8 @@
 using System;
-
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
+    using Microsoft.Language.Xml.Utilities;
 
     public class XmlAttributeSyntax : XmlNodeSyntax, INamedXmlNode
     {
@@ -87,93 +87,25 @@ namespace Microsoft.Language.Xml
 
         public bool IsNamespaceDeclaration => string.Equals(NameNode?.Prefix, "xmlns", StringComparison.Ordinal);
 
-        public string Value
-        {
-            get
-            {
-                if (ValueNode == null)
-                {
-                    return null;
-                }
-
-                var xmlString = ValueNode;
-                if (xmlString == null)
-                {
-                    return null;
-                }
-
-                if (xmlString.TextTokens.Node == null)
-                {
-                    return "";
-                }
-
-                return xmlString.TextTokens.Node.ToFullString();
-            }
-        }
-
         /// <summary>
-        /// Get Normalized <see cref="Value"/> of <see cref="XmlStringSyntax"/>
+        /// Get attribute normalized value
         /// </summary>
         /// <remarks>
         /// Normalization specs:
         /// <seealso href="https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-line-ends">2.2.12 [XML] Section 3.3.3</seealso/>
         /// <seealso href="https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae">2.11 [XML} End-of-Line Handling</seealso/>
         /// </remarks>
-        public string NormalizedValue
+        public string Value
         {
             get
             {
-                if (ValueNode is { } xmlString)
+                if (ValueNode is XmlStringSyntax xmlString)
                 {
-                    if (xmlString.TextTokens.Node is null)
+                    return xmlString.TextTokens.Node switch
                     {
-                        return "";
-                    }
-
-                    var sb = PooledStringBuilder.GetInstance();
-
-                    var tokens = xmlString.TextTokens;
-                    var ntokens = tokens.Count;
-
-                    for (int tokenIndex = 0; tokenIndex < ntokens; tokenIndex++)
-                    {
-                        char lastChar = default;
-                        if (tokens[tokenIndex] is XmlTextTokenSyntax token)
-                        {
-                            var width = token.Width;
-
-                            for (int charIndex = 0; charIndex < width; charIndex++)
-                            {
-                                var c = token.Text[charIndex];
-                                switch (c)
-                                {
-                                    // If there is a sequence of CR and LF or CR 0x85 or CR 0x2028 replace them with a space (0x32)
-                                    case '\r' when (charIndex + 1 < width && (token.Text[charIndex + 1] is '\n' or '\x85' or '\x2028')):
-                                        sb.Builder.Append(' ');
-                                        charIndex++; // Skip next onece
-                                        break;
-                                    // If current char is single CR or 0x85 or 0x2028 replace with a space(0x32)
-                                    case '\r':
-                                    case '\x85':
-                                    case '\x2000':
-                                        sb.Builder.Append(' ');
-                                        break;
-                                    // if current char is LF and previus not is LF or CR 
-                                    case '\n' when lastChar != '\n' && lastChar != '\r':
-                                        sb.Builder.Append(' ');
-                                        break;
-                                    case '\t':
-                                        sb.Builder.Append(' ');
-                                        break;
-                                    default:
-                                        sb.Builder.Append(c);
-                                        break;
-                                }
-                                lastChar = c;
-                            }
-                        }
-                    }
-                    return sb.ToStringAndFree();
+                        SyntaxNode node => node.GetNormalizedAttributeValue(),
+                        _ => string.Empty
+                    };
                 }
                 return null;
             }

--- a/src/Microsoft.Language.Xml/Utilities/Normalization.cs
+++ b/src/Microsoft.Language.Xml/Utilities/Normalization.cs
@@ -1,0 +1,73 @@
+using System.Text;
+
+namespace Microsoft.Language.Xml.Utilities
+{
+    public static class Normalization
+    {
+        /// <summary>
+        /// Get normalized value
+        /// </summary>
+        /// <param name="value"><see cref="string"/> to normalize.</param>
+        /// <remarks>
+        /// Normalization specs:
+        /// <seealso href="https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-line-ends">2.2.12 [XML] Section 3.3.3</seealso/>
+        /// <seealso href="https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae">2.11 [XML} End-of-Line Handling</seealso/>
+        /// </remarks>
+        public static string GetNormalizedAttributeValue(this string value) =>
+            GetNormalizedAttributeValue(new StringBuilder(value));
+
+        internal static string GetNormalizedAttributeValue(StringBuilder inputBuffer)
+        {
+            var outputBuffer = PooledStringBuilder.GetInstance();
+            NormalizeAttributeValueTo(inputBuffer, outputBuffer);
+            return outputBuffer.ToStringAndFree();
+        }
+
+        internal static string GetNormalizedAttributeValue(this SyntaxNode node)
+        {
+            var inputBuffer = PooledStringBuilder.GetInstance();
+            var writer = new System.IO.StringWriter(inputBuffer.Builder, System.Globalization.CultureInfo.InvariantCulture);
+            node.WriteTo(writer);
+            var outputBuffer = PooledStringBuilder.GetInstance();
+            inputBuffer.Builder.NormalizeAttributeValueTo(outputBuffer);
+            inputBuffer.Free();
+            return outputBuffer.ToStringAndFree();
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static void NormalizeAttributeValueTo(this StringBuilder inputBuffer, PooledStringBuilder outputBuffer)
+        {
+            var inputBufferLength = inputBuffer.Length;
+            char lastChar = default;
+            for (int charIndex = 0; charIndex < inputBufferLength; charIndex++)
+            {
+                var c = inputBuffer[charIndex];
+                switch (c)
+                {
+                    // If there is a sequence of CR and LF or CR 0x85 or CR 0x2028 replace them with a space (0x32)
+                    case '\r' when (charIndex + 1 < inputBufferLength && (inputBuffer[charIndex + 1] is '\n' or '\x85' or '\x2028')):
+                        outputBuffer.Builder.Append(' ');
+                        charIndex++; // Skip next onece
+                        break;
+                    // If current char is single CR or 0x85 or 0x2028 replace with a space(0x32)
+                    case '\r':
+                    case '\x85':
+                    case '\x2000':
+                        outputBuffer.Builder.Append(' ');
+                        break;
+                    // if current char is LF and previus not is LF or CR 
+                    case '\n' when lastChar != '\n' && lastChar != '\r':
+                        outputBuffer.Builder.Append(' ');
+                        break;
+                    case '\t':
+                        outputBuffer.Builder.Append(' ');
+                        break;
+                    default:
+                        outputBuffer.Builder.Append(c);
+                        break;
+                }
+                lastChar = c;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Address [spec](https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae)

Currently the `TestParser.ExhaustiveSubstring` test fails, but I don't understand why. Do you have an idea?