### PR TITLE
Make helpers internal

### DIFF
--- a/src/Microsoft.Language.Xml/ErrorFactory.cs
+++ b/src/Microsoft.Language.Xml/ErrorFactory.cs
@@ -1,25 +1,23 @@
-﻿using System;
-
 namespace Microsoft.Language.Xml
 {
-    public class ErrorFactory
+    internal static class ErrorFactory
     {
-        internal static DiagnosticInfo ErrorInfo(ERRID errID)
+        public static DiagnosticInfo ErrorInfo(ERRID errID)
         {
             return new DiagnosticInfo(errID);
         }
 
-        internal static DiagnosticInfo ErrorInfo(ERRID errID, object[] arguments)
+        public static DiagnosticInfo ErrorInfo(ERRID errID, object[] arguments)
         {
             return new DiagnosticInfo(errID, arguments);
         }
 
-        internal static DiagnosticInfo ErrorInfo(ERRID errID, char xmlCh, string v)
+        public static DiagnosticInfo ErrorInfo(ERRID errID, char xmlCh, string v)
         {
             return new DiagnosticInfo(errID, new object[] { xmlCh, v });
         }
 
-        internal static DiagnosticInfo ErrorInfo(ERRID errID, string xmlCh, string v)
+        public static DiagnosticInfo ErrorInfo(ERRID errID, string xmlCh, string v)
         {
             return new DiagnosticInfo(errID, new object[] { xmlCh, v });
         }

--- a/src/Microsoft.Language.Xml/Extensions.cs
+++ b/src/Microsoft.Language.Xml/Extensions.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
 namespace Microsoft.Language.Xml
 {
-    public static class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// Search a sorted integer array for the target value in O(log N) time.
@@ -13,7 +11,7 @@ namespace Microsoft.Language.Xml
         /// inserted in order to maintain the sorted order. All values to the right of this position will be
         /// strictly greater than <paramref name="value"/>. Note that this may return a position off the end
         /// of the array if all elements are less than or equal to <paramref name="value"/>.</returns>
-        internal static int BinarySearchUpperBound(this int[] array, int value)
+        public static int BinarySearchUpperBound(this int[] array, int value)
         {
             int low = 0;
             int high = array.Length - 1;
@@ -34,7 +32,7 @@ namespace Microsoft.Language.Xml
             return low;
         }
 
-        internal static bool OverlapsWithAny(this TextSpan span, TextSpan[] otherSpans)
+        public static bool OverlapsWithAny(this TextSpan span, TextSpan[] otherSpans)
         {
             foreach (var other in otherSpans)
             {
@@ -54,7 +52,7 @@ namespace Microsoft.Language.Xml
             return false;
         }
 
-        internal static bool AnyContainsPosition(this TextSpan[] spans, int position)
+        public static bool AnyContainsPosition(this TextSpan[] spans, int position)
         {
             foreach (var span in spans)
             {


### PR DESCRIPTION
Both classes have `internal` methods only. I guess, it makes more sense to mark the whole class as `internal` and don't expose these empty names to the public then