### PR TITLE
Make node flags internal

### DIFF
--- a/src/Microsoft.Language.Xml/InternalSyntax/NodeFlags.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/NodeFlags.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 
 namespace Microsoft.Language.Xml.InternalSyntax
 {
     [Flags]
-    public enum NodeFlags : byte
+    internal enum NodeFlags : byte
     {
         None = 0,
         ContainsDiagnostics = 1 << 0,


### PR DESCRIPTION
It is definitely not ok to have a public member in an `InternalSyntax` namespace)