### PR TITLE
Improve benchmarks

### DIFF
--- a/benchmark/Microsoft.Language.Xml.Benchmarks/Microsoft.Language.Xml.Benchmarks.csproj
+++ b/benchmark/Microsoft.Language.Xml.Benchmarks/Microsoft.Language.Xml.Benchmarks.csproj
@@ -1,13 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.Language.Xml.Benchmarks</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Language.Xml\Microsoft.Language.Xml.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
   </ItemGroup>
 </Project>

--- a/benchmark/Microsoft.Language.Xml.Benchmarks/ParserBenchmarks.cs
+++ b/benchmark/Microsoft.Language.Xml.Benchmarks/ParserBenchmarks.cs
@@ -4,8 +4,8 @@ using BenchmarkDotNet.Jobs;
 namespace Microsoft.Language.Xml.Benchmarks;
 
 [MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net472)]
-[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net472, id: ".NET Framework")]
+[SimpleJob(RuntimeMoniker.Net80, id: "Modern .NET")]
 public class ParserBenchmarks
 {
     private Buffer textBuffer;

--- a/benchmark/Microsoft.Language.Xml.Benchmarks/ParserBenchmarks.cs
+++ b/benchmark/Microsoft.Language.Xml.Benchmarks/ParserBenchmarks.cs
@@ -1,20 +1,21 @@
-﻿using System;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
-namespace Microsoft.Language.Xml.Benchmarks
+namespace Microsoft.Language.Xml.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net472)]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class ParserBenchmarks
 {
-    [MemoryDiagnoser]
-    [SimpleJob(launchCount: 1, warmupCount: 3, targetCount: 50)]
-    public class ParserBenchmarks
+    private Buffer textBuffer;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        readonly Buffer textBuffer;
-
-        public ParserBenchmarks()
-        {
-            textBuffer = new StringBuffer(XmlSnippets.LongAndroidLayoutXml);
-        }
-
-        [Benchmark]
-        public void ParseLongXml() => Parser.Parse(textBuffer);
+        textBuffer = new StringBuffer(XmlSnippets.LongAndroidLayoutXml);
     }
+
+    [Benchmark]
+    public void ParseLongXml() => Parser.Parse(textBuffer);
 }

--- a/benchmark/Microsoft.Language.Xml.Benchmarks/Program.cs
+++ b/benchmark/Microsoft.Language.Xml.Benchmarks/Program.cs
@@ -1,12 +1,4 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
+using Microsoft.Language.Xml.Benchmarks;
 
-namespace Microsoft.Language.Xml.Benchmarks
-{
-    class Program
-    {
-        public static void Main(string[] args)
-        {
-            BenchmarkRunner.Run<ParserBenchmarks>();
-        }
-    }
-}
+BenchmarkRunner.Run<ParserBenchmarks>();

--- a/benchmark/Microsoft.Language.Xml.Benchmarks/XmlSnippets.cs
+++ b/benchmark/Microsoft.Language.Xml.Benchmarks/XmlSnippets.cs
@@ -1,214 +1,213 @@
-﻿using System;
+namespace Microsoft.Language.Xml.Benchmarks;
 
-namespace Microsoft.Language.Xml.Benchmarks
+public static class XmlSnippets
 {
-    public static class XmlSnippets
-    {
-        public const string LongAndroidLayoutXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<moyeu.InfoPane xmlns:android=""http://schemas.android.com/apk/res/android""
-    android:id=""@+id/infoPane""
-    android:orientation=""vertical""
-    android:layout_height=""wrap_content""
-    android:layout_width=""match_parent""
-    android:layout_gravity=""bottom""
-    android:paddingTop=""4dp"">
-    <FrameLayout
-        android:layout_height=""72dp""
-        android:layout_width=""match_parent""
-        android:paddingEnd=""16dp""
-        android:paddingStart=""16dp""
-        android:background=""@color/card_background""
-        android:id=""@+id/PaneHeaderView"">
-        <LinearLayout
-            android:orientation=""vertical""
-            android:layout_height=""wrap_content""
-            android:layout_width=""match_parent""
-            android:layout_gravity=""center"">
+    public const string LongAndroidLayoutXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <moyeu.InfoPane xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/infoPane"
+            android:orientation="vertical"
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_gravity="bottom"
+            android:paddingTop="4dp">
+            <FrameLayout
+                android:layout_height="72dp"
+                android:layout_width="match_parent"
+                android:paddingEnd="16dp"
+                android:paddingStart="16dp"
+                android:background="@color/card_background"
+                android:id="@+id/PaneHeaderView">
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:layout_gravity="center">
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:paddingRight="72dp">
+                        <TextView
+                            android:id="@+id/InfoViewName"
+                            android:text="Union Square"
+                            android:layout_width="0px"
+                            android:layout_weight="1"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                            android:lines="1"
+                            android:ellipsize="end" />
+                        <TextView
+                            android:text="8"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="right|center_vertical"
+                            android:minWidth="32dp"
+                            android:id="@+id/InfoViewBikeNumber"
+                            android:textColor="#000000"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="4dp"
+                            android:src="@android:color/transparent"
+                            android:id="@+id/InfoViewBikeNumberImg"
+                            android:baseline="15dp" />
+                    </LinearLayout>
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:baselineAligned="true">
+                        <TextView
+                            android:id="@+id/InfoViewSecondName"
+                            android:text="Somerville"
+                            android:layout_width="0px"
+                            android:layout_weight="1"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                            android:lines="1"
+                            android:ellipsize="end" />
+                        <TextView
+                            android:text="6"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="right"
+                            android:minWidth="32dp"
+                            android:id="@+id/InfoViewSlotNumber"
+                            android:textColor="#000000"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="4dp"
+                            android:src="@android:color/transparent"
+                            android:id="@+id/InfoViewSlotNumberImg"
+                            android:layout_gravity="center_vertical" />
+                        <TextView
+                            android:id="@+id/InfoViewDistance"
+                            android:layout_width="56dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="16dp"
+                            android:lines="1"
+                            android:ellipsize="end"
+                            android:text="6 miles"
+                            android:gravity="center_horizontal"
+                            android:textColor="?android:attr/textColorSecondary"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
+                        <ImageView
+                            android:id="@+id/stationLock"
+                            android:src="@drawable/ic_station_lock"
+                            android:layout_marginLeft="35dp"
+                            android:layout_marginRight="19dp"
+                            android:tint="@color/lock_icon_tint"
+                            android:scaleType="center"
+                            android:adjustViewBounds="true"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:visibility="gone"
+                            android:layout_gravity="center_vertical" />
+                    </LinearLayout>
+                </LinearLayout>
+            </FrameLayout>
             <LinearLayout
-                android:orientation=""horizontal""
-                android:layout_height=""wrap_content""
-                android:layout_width=""match_parent""
-                android:paddingRight=""72dp"">
+                android:background="@color/card_background"
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_weight="1"
+                android:layout_height="wrap_content">
                 <TextView
-                    android:id=""@+id/InfoViewName""
-                    android:text=""Union Square""
-                    android:layout_width=""0px""
-                    android:layout_weight=""1""
-                    android:layout_height=""wrap_content""
-                    android:textColor=""?android:attr/textColorPrimary""
-                    android:textAppearance=""@style/TextAppearance.AppCompat.Title""
-                    android:lines=""1""
-                    android:ellipsize=""end"" />
+                    android:text="Activity"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    style="@style/info_pane_section" />
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/time_cell_bg"
+                        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+                        <ImageView
+                            android:src="@drawable/ic_clock"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/clockImg"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginRight="8dp"
+                            android:tint="@color/black_tint_primary"
+                            android:adjustViewBounds="true"
+                            android:layout_marginTop="3dp"
+                            android:layout_marginBottom="3dp" />
+                        <TextView
+                            android:id="@+id/historyTime1"
+                            style="@style/activity_time_entry" />
+                        <TextView
+                            android:id="@+id/historyTime2"
+                            style="@style/activity_time_entry" />
+                        <TextView
+                            android:id="@+id/historyTime3"
+                            style="@style/activity_time_entry" />
+                        <TextView
+                            android:id="@+id/historyTime4"
+                            style="@style/activity_time_entry" />
+                        <TextView
+                            android:id="@+id/historyTime5"
+                            style="@style/activity_time_entry" />
+                    </LinearLayout>
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+                        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+                        <ImageView
+                            android:src="@drawable/ic_bike_number"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/bikeNumberImg"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginRight="8dp"
+                            android:adjustViewBounds="true"
+                            android:layout_marginTop="3dp"
+                            android:layout_marginBottom="3dp"
+                            android:tint="@color/black_tint_primary" />
+                        <TextView
+                            android:id="@+id/historyValue1"
+                            style="@style/activity_number_entry" />
+                        <TextView
+                            android:id="@+id/historyValue2"
+                            style="@style/activity_number_entry" />
+                        <TextView
+                            android:id="@+id/historyValue3"
+                            style="@style/activity_number_entry" />
+                        <TextView
+                            android:id="@+id/historyValue4"
+                            style="@style/activity_number_entry" />
+                        <TextView
+                            android:id="@+id/historyValue5"
+                            style="@style/activity_number_entry" />
+                    </LinearLayout>
+                </LinearLayout>
                 <TextView
-                    android:text=""8""
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:gravity=""right|center_vertical""
-                    android:minWidth=""32dp""
-                    android:id=""@+id/InfoViewBikeNumber""
-                    android:textColor=""#000000""
-                    android:textSize=""18sp""
-                    android:textStyle=""bold"" />
-                <ImageView
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:layout_marginLeft=""4dp""
-                    android:src=""@android:color/transparent""
-                    android:id=""@+id/InfoViewBikeNumberImg""
-                    android:baseline=""15dp"" />
+                    android:text="Location"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    style="@style/info_pane_section" />
+                <com.google.android.gms.maps.StreetViewPanoramaView
+                    android:background="@android:color/white"
+                    android:id="@+id/streetViewPanorama"
+                    android:layout_width="match_parent"
+                    android:layout_height="160dp" />
             </LinearLayout>
-            <LinearLayout
-                android:orientation=""horizontal""
-                android:layout_height=""wrap_content""
-                android:layout_width=""match_parent""
-                android:baselineAligned=""true"">
-                <TextView
-                    android:id=""@+id/InfoViewSecondName""
-                    android:text=""Somerville""
-                    android:layout_width=""0px""
-                    android:layout_weight=""1""
-                    android:layout_height=""wrap_content""
-                    android:textColor=""?android:attr/textColorPrimary""
-                    android:textAppearance=""@style/TextAppearance.AppCompat.Subhead""
-                    android:lines=""1""
-                    android:ellipsize=""end"" />
-                <TextView
-                    android:text=""6""
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:gravity=""right""
-                    android:minWidth=""32dp""
-                    android:id=""@+id/InfoViewSlotNumber""
-                    android:textColor=""#000000""
-                    android:textSize=""18sp""
-                    android:textStyle=""bold"" />
-                <ImageView
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:layout_marginLeft=""4dp""
-                    android:src=""@android:color/transparent""
-                    android:id=""@+id/InfoViewSlotNumberImg""
-                    android:layout_gravity=""center_vertical"" />
-                <TextView
-                    android:id=""@+id/InfoViewDistance""
-                    android:layout_width=""56dp""
-                    android:layout_height=""wrap_content""
-                    android:layout_marginLeft=""16dp""
-                    android:lines=""1""
-                    android:ellipsize=""end""
-                    android:text=""6 miles""
-                    android:gravity=""center_horizontal""
-                    android:textColor=""?android:attr/textColorSecondary""
-                    android:textAppearance=""@style/TextAppearance.AppCompat.Caption"" />
-                <ImageView
-                    android:id=""@+id/stationLock""
-                    android:src=""@drawable/ic_station_lock""
-                    android:layout_marginLeft=""35dp""
-                    android:layout_marginRight=""19dp""
-                    android:tint=""@color/lock_icon_tint""
-                    android:scaleType=""center""
-                    android:adjustViewBounds=""true""
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:visibility=""gone""
-                    android:layout_gravity=""center_vertical"" />
-            </LinearLayout>
-        </LinearLayout>
-    </FrameLayout>
-    <LinearLayout
-        android:background=""@color/card_background""
-        android:orientation=""vertical""
-        android:layout_width=""match_parent""
-        android:layout_weight=""1""
-        android:layout_height=""wrap_content"">
-        <TextView
-            android:text=""Activity""
-            android:layout_width=""wrap_content""
-            android:layout_height=""wrap_content""
-            style=""@style/info_pane_section"" />
-        <LinearLayout
-            android:orientation=""vertical""
-            android:layout_width=""match_parent""
-            android:layout_height=""wrap_content"">
-            <LinearLayout
-                android:orientation=""horizontal""
-                android:layout_width=""match_parent""
-                android:layout_height=""wrap_content""
-                android:background=""@drawable/time_cell_bg""
-                android:paddingStart=""?android:attr/listPreferredItemPaddingStart""
-                android:paddingEnd=""?android:attr/listPreferredItemPaddingEnd"">
-                <ImageView
-                    android:src=""@drawable/ic_clock""
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:id=""@+id/clockImg""
-                    android:layout_gravity=""center_vertical""
-                    android:layout_marginRight=""8dp""
-                    android:tint=""@color/black_tint_primary""
-                    android:adjustViewBounds=""true""
-                    android:layout_marginTop=""3dp""
-                    android:layout_marginBottom=""3dp"" />
-                <TextView
-                    android:id=""@+id/historyTime1""
-                    style=""@style/activity_time_entry"" />
-                <TextView
-                    android:id=""@+id/historyTime2""
-                    style=""@style/activity_time_entry"" />
-                <TextView
-                    android:id=""@+id/historyTime3""
-                    style=""@style/activity_time_entry"" />
-                <TextView
-                    android:id=""@+id/historyTime4""
-                    style=""@style/activity_time_entry"" />
-                <TextView
-                    android:id=""@+id/historyTime5""
-                    style=""@style/activity_time_entry"" />
-            </LinearLayout>
-            <LinearLayout
-                android:orientation=""horizontal""
-                android:layout_width=""match_parent""
-                android:layout_height=""wrap_content""
-                android:paddingStart=""?android:attr/listPreferredItemPaddingStart""
-                android:paddingEnd=""?android:attr/listPreferredItemPaddingEnd"">
-                <ImageView
-                    android:src=""@drawable/ic_bike_number""
-                    android:layout_width=""wrap_content""
-                    android:layout_height=""wrap_content""
-                    android:id=""@+id/bikeNumberImg""
-                    android:layout_gravity=""center_vertical""
-                    android:layout_marginRight=""8dp""
-                    android:adjustViewBounds=""true""
-                    android:layout_marginTop=""3dp""
-                    android:layout_marginBottom=""3dp""
-                    android:tint=""@color/black_tint_primary"" />
-                <TextView
-                    android:id=""@+id/historyValue1""
-                    style=""@style/activity_number_entry"" />
-                <TextView
-                    android:id=""@+id/historyValue2""
-                    style=""@style/activity_number_entry"" />
-                <TextView
-                    android:id=""@+id/historyValue3""
-                    style=""@style/activity_number_entry"" />
-                <TextView
-                    android:id=""@+id/historyValue4""
-                    style=""@style/activity_number_entry"" />
-                <TextView
-                    android:id=""@+id/historyValue5""
-                    style=""@style/activity_number_entry"" />
-            </LinearLayout>
-        </LinearLayout>
-        <TextView
-            android:text=""Location""
-            android:layout_width=""wrap_content""
-            android:layout_height=""wrap_content""
-            style=""@style/info_pane_section"" />
-        <com.google.android.gms.maps.StreetViewPanoramaView
-            android:background=""@android:color/white""
-            android:id=""@+id/streetViewPanorama""
-            android:layout_width=""match_parent""
-            android:layout_height=""160dp"" />
-    </LinearLayout>
-</moyeu.InfoPane>";
-    }
+        </moyeu.InfoPane>
+        """;
 }


### PR DESCRIPTION
- Updated version of `BenchmarkDotNet`
- Modernized code a little bit
- Made benchmarks run on .NET Framework and .NET 8

I was actually surprised by the difference between .NET Framework and .NET 8:
```
BenchmarkDotNet v0.13.10, Windows 11 (10.0.22621.2715/22H2/2022Update/SunValley2)
AMD Ryzen 7 5800X, 1 CPU, 16 logical and 8 physical cores
  [Host]         : .NET Framework 4.8.1 (4.8.9181.0), X64 RyuJIT VectorSize=256
  .NET Framework : .NET Framework 4.8.1 (4.8.9181.0), X64 RyuJIT VectorSize=256
  Modern .NET    : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
```
| Method       | Job            | Runtime              | Mean     | Error   | StdDev  | Gen0    | Gen1   | Gen2   | Allocated |
|------------- |--------------- |--------------------- |---------:|--------:|--------:|--------:|-------:|-------:|----------:|
| ParseLongXml | .NET Framework | .NET Framework 4.7.2 | 218.2 us | 0.84 us | 0.74 us | 33.4473 | 1.2207 |      - | 205.75 KB |
| ParseLongXml | Modern .NET    | .NET 8.0             | 127.8 us | 0.41 us | 0.38 us | 11.4746 | 2.9297 | 1.2207 | 188.11 KB |