### PR TITLE
Multitarget main library and its tests

### DIFF
--- a/src/Microsoft.Language.Xml/Microsoft.Language.Xml.csproj
+++ b/src/Microsoft.Language.Xml/Microsoft.Language.Xml.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.Language.Xml</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.84" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" Condition="'$(TargetFramework)'=='netstandard2.0'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -219,9 +219,9 @@ namespace Microsoft.Language.Xml
         public override int GetSlotCountIncludingTrivia()
         {
             int triviaSlots = 0;
-            if (GetLeadingTrivia() != null)
+            if (GetLeadingTrivia() != default)
                 triviaSlots++;
-            if (GetTrailingTrivia() != null)
+            if (GetTrailingTrivia() != default)
                 triviaSlots++;
 
             return triviaSlots;

--- a/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -161,7 +161,7 @@ namespace Microsoft.Language.Xml
         {
             get
             {
-                if (AttributesNode == null)
+                if (AttributesNode == default)
                 {
                     yield break;
                 }

--- a/test/Microsoft.Language.Xml.Tests/Microsoft.Language.Xml.Tests.csproj
+++ b/test/Microsoft.Language.Xml.Tests/Microsoft.Language.Xml.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.Language.Xml.Tests</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsWindows>$([MSBuild]::IsOSPlatform('Windows'))</IsWindows>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,9 +10,13 @@
     <DelaySign>False</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" Condition="!$(IsWindows)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.6.3" Condition="!$(IsWindows)" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
- Made `MS.Language.Xml` multitarget .NET Standard 2.0 and all currently supported .NETs
- Fixed several warning reported for higher versions of .NET
- Updated `System.Collection.Immutable` reference to the latest version and scoped it to `netstandard2.0` since it is included to the standard library for modern .NETs by default
- Multitargeted test project for `MS.Language.Xml` and made it run .NET tests (this includes adding `Microsoft.NET.Test.Sdk` package reference since .NET test cannot be run without it)
- Updated `xunit` versions to the latest available