### PR TITLE
Avoid comparing structs to `null` (use `default` instead)

### DIFF
--- a/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -219,9 +219,9 @@ namespace Microsoft.Language.Xml
         public override int GetSlotCountIncludingTrivia()
         {
             int triviaSlots = 0;
-            if (GetLeadingTrivia() != null)
+            if (GetLeadingTrivia() != default)
                 triviaSlots++;
-            if (GetTrailingTrivia() != null)
+            if (GetTrailingTrivia() != default)
                 triviaSlots++;
 
             return triviaSlots;

--- a/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -161,7 +161,7 @@ namespace Microsoft.Language.Xml
         {
             get
             {
-                if (AttributesNode == null)
+                if (AttributesNode == default)
                 {
                     yield break;
                 }


### PR DESCRIPTION
Extraced from https://github.com/KirillOsenkov/XmlParser/pull/52