### PR TITLE
Remove workaround for installing .NET 8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.2.{build}
 image: Visual Studio 2022
 before_build:
-- cmd: choco install dotnet-sdk --version 8.0.100
 - cmd: dotnet restore
 build:
   project: Microsoft.Language.Xml.sln


### PR DESCRIPTION
According to appveyor release notes, .NET SDK 8.0.100 should already be insluded into the base image, so no need to install it