### PR TITLE
Preserve annotations on modification.

### DIFF
--- a/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
@@ -144,13 +144,13 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlDocument(
+                return node.CopyAnnotationsTo(XmlDocument(
                     newDeclaration,
                     newPrecedingMisc.Node,
                     newRoot,
                     newFollowingMisc.Node,
                     newSkippedTokens,
-                    newEof);
+                    newEof));
             }
             else
             {
@@ -199,13 +199,13 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlDeclaration(
+                return node.CopyAnnotationsTo(XmlDeclaration(
                     newLessThanQuestionToken,
                     newXmlKeyword,
                     newVersion,
                     newEncoding,
                     newStandalone,
-                    newQuestionGreaterThanToken);
+                    newQuestionGreaterThanToken));
             }
             else
             {
@@ -236,7 +236,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlDeclarationOption(newName, newEquals, newValue);
+                return node.CopyAnnotationsTo(XmlDeclarationOption(newName, newEquals, newValue));
             }
             else
             {
@@ -267,7 +267,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlElement(newStartTag, newContent.Node, newEndTag);
+                return node.CopyAnnotationsTo(XmlElement(newStartTag, newContent.Node, newEndTag));
             }
             else
             {
@@ -286,7 +286,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlText(newTextTokens.Node);
+                return node.CopyAnnotationsTo(XmlText(newTextTokens.Node));
             }
             else
             {
@@ -323,7 +323,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlElementStartTag(newLessThanToken, newName, newAttributes.Node, newGreaterThanToken);
+                return node.CopyAnnotationsTo(XmlElementStartTag(newLessThanToken, newName, newAttributes.Node, newGreaterThanToken));
             }
             else
             {
@@ -354,7 +354,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlElementEndTag(newLessThanSlashToken, newName, newGreaterThanToken);
+                return node.CopyAnnotationsTo(XmlElementEndTag(newLessThanSlashToken, newName, newGreaterThanToken));
             }
             else
             {
@@ -391,7 +391,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlEmptyElement(newLessThanToken, newName, newAttributes.Node, newSlashGreaterThanToken);
+                return node.CopyAnnotationsTo(XmlEmptyElement(newLessThanToken, newName, newAttributes.Node, newSlashGreaterThanToken));
             }
             else
             {
@@ -422,7 +422,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlAttribute(newName, newEqualsToken, newValue);
+                return node.CopyAnnotationsTo(XmlAttribute(newName, newEqualsToken, newValue));
             }
             else
             {
@@ -453,7 +453,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlString(newStartQuoteToken, newTextTokens.Node, newEndQuoteToken);
+                return node.CopyAnnotationsTo(XmlString(newStartQuoteToken, newTextTokens.Node, newEndQuoteToken));
             }
             else
             {
@@ -478,7 +478,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlName(newPrefix, newLocalName);
+                return node.CopyAnnotationsTo(XmlName(newPrefix, newLocalName));
             }
             else
             {
@@ -503,7 +503,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlPrefix(newName, newColonToken);
+                return node.CopyAnnotationsTo(XmlPrefix(newName, newColonToken));
             }
             else
             {
@@ -534,7 +534,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlComment(newLessThanExclamationMinusMinusToken, newTextTokens.Node, newMinusMinusGreaterThanToken);
+                return node.CopyAnnotationsTo(XmlComment(newLessThanExclamationMinusMinusToken, newTextTokens.Node, newMinusMinusGreaterThanToken));
             }
             else
             {
@@ -571,7 +571,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlProcessingInstruction(newLessThanQuestionToken, newName, newTextTokens.Node, newQuestionGreaterThanToken);
+                return node.CopyAnnotationsTo(XmlProcessingInstruction(newLessThanQuestionToken, newName, newTextTokens.Node, newQuestionGreaterThanToken));
             }
             else
             {
@@ -602,7 +602,7 @@ namespace Microsoft.Language.Xml
 
             if (anyChanges)
             {
-                return XmlCDataSection(newBeginCDataToken, newTextTokens.Node, newEndCDataToken);
+                return node.CopyAnnotationsTo(XmlCDataSection(newBeginCDataToken, newTextTokens.Node, newEndCDataToken));
             }
             else
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
@@ -236,8 +236,11 @@ namespace Microsoft.Language.Xml
             var startTag = SyntaxFactory.XmlElementStartTag(this.LessThanToken, this.NameNode, this.AttributesNode, greaterThanToken);
             var lessThanSlashToken = SyntaxFactory.Punctuation(SyntaxKind.LessThanSlashToken, "</", null, null);
             var endTag = SyntaxFactory.XmlElementEndTag(lessThanSlashToken, this.NameNode, greaterThanToken);
-
-            return SyntaxFactory.XmlElement(startTag, content, endTag);
+            var newNode = SyntaxFactory.XmlElement(startTag, content, endTag);
+            var annotations = this.GetAnnotations();
+            if (annotations != null && annotations.Length > 0)
+                return newNode.WithAnnotations(annotations);
+            return newNode;
         }
 
         public XmlEmptyElementSyntax WithSlashGreaterThanToken(PunctuationSyntax slashGreaterThanToken)

--- a/test/Microsoft.Language.Xml.Tests/TestAnnotations.cs
+++ b/test/Microsoft.Language.Xml.Tests/TestAnnotations.cs
@@ -1,0 +1,69 @@
+using System;
+using Xunit;
+
+namespace Microsoft.Language.Xml.Tests
+{
+    public class TestAnnotations
+    {
+        private static readonly SyntaxAnnotation annotation = new SyntaxAnnotation("test");
+
+        [Fact]
+        public void AddingContentToElementPreservesAnnotations()
+        {
+            var root = GetRootElementSyntax("<root><child/></root>");
+            var child = Parser.ParseText("<child2/>").RootSyntax;
+
+            AssertAnnotation(root.AddChild(child));
+        }
+
+        [Fact]
+        public void AddingChildToEmptyElementPreservesAnnotations()
+        {
+            var root = GetRootEmptyElementSyntax("<root/>");
+            var child = Parser.ParseText("<child2/>").RootSyntax;
+
+            AssertAnnotation(root.AddChild(child));
+        }
+
+        [Fact]
+        public void AddingElementTriviaPreservesAnnotations()
+        {
+            var root = GetRootElementSyntax("<root></root>");
+            var trivia = SyntaxFactory.WhitespaceTrivia(" ");
+
+            AssertAnnotation(root.WithLeadingTrivia(trivia));
+        }
+
+        [Fact]
+        public void AddingEmptyElementTriviaPreservesAnnotations()
+        {
+            var root = GetRootEmptyElementSyntax("<root/>");
+            var trivia = SyntaxFactory.WhitespaceTrivia(" ");
+
+            AssertAnnotation(root.WithLeadingTrivia(trivia));
+        }
+
+        private static void AssertAnnotation<T>(T element) where T : SyntaxNode
+        {
+            Assert.True(element.ContainsAnnotations);
+            element.HasAnnotation(annotation);
+        }
+
+        private static void AssertAnnotation(IXmlElementSyntax element)
+        {
+            AssertAnnotation((SyntaxNode)element);
+        }
+
+        private static XmlElementSyntax GetRootElementSyntax(string xml)
+        {
+            return Assert.IsType<XmlElementSyntax>(Parser.ParseText(xml).RootSyntax)
+                .WithAdditionalAnnotations(annotation);
+        }
+
+        private static XmlEmptyElementSyntax GetRootEmptyElementSyntax(string xml)
+        {
+            return Assert.IsType<XmlEmptyElementSyntax>(Parser.ParseText(xml).RootSyntax)
+                .WithAdditionalAnnotations(annotation);
+        }
+    }
+}


### PR DESCRIPTION
Certain modifications to the tree were not preserving annotations: most notably those in `SyntaxRewriter` but also in `XmlEmptyElementSyntax.WithContent`. This makes modifying the XML difficult as it makes it difficult to [keep track of syntax nodes across edits](https://joshvarty.com/2015/09/18/learn-roslyn-now-part-13-keeping-track-of-syntax-nodes-with-syntax-annotations/) without this.

This PR:

- [Adds some failing annotations tests](https://github.com/KirillOsenkov/XmlParser/commit/3975f0b280bc6f9cc811b53603197e0ba76138fb)
- [Fixes those tests ](https://github.com/KirillOsenkov/XmlParser/commit/086582a849a3d490805400247b3ad60e4e5b6b8a)

I don't want to guarantee I've found all the places where annotations aren't being preserved, but this should improve things somwehat. I also didn't add tests for every case that I found in `SyntaxRewriter`; just enough to get an idea.