### PR TITLE
Add nullable annotations.

### DIFF
--- a/src/Microsoft.Language.Xml/Blender.cs
+++ b/src/Microsoft.Language.Xml/Blender.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#pragma warning disable CS8602
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
@@ -9,9 +12,9 @@ namespace Microsoft.Language.Xml
     internal sealed class Blender : Scanner
     {
         private readonly Stack<GreenNode> _nodeStack = new Stack<GreenNode>();
-        private readonly TextChangeRange[] _changes;
-        private readonly TextSpan[] _affectedRanges;
-        private GreenNode _currentNode;
+        private readonly TextChangeRange[]? _changes;
+        private readonly TextSpan[]? _affectedRanges;
+        private GreenNode? _currentNode;
         private int _curNodeStart;
         private int _curNodeLength;
         private readonly SyntaxNode _baseTreeRoot;
@@ -98,7 +101,7 @@ namespace Microsoft.Language.Xml
             return TextSpan.FromBounds(start, end);
         }
 
-        internal override GreenNode GetCurrentSyntaxNode()
+        internal override GreenNode? GetCurrentSyntaxNode()
         {
             if (_currentNode == null)
                 return null;
@@ -191,7 +194,7 @@ namespace Microsoft.Language.Xml
 
         private static bool ShouldCrumble(GreenNode node) => true;
 
-        private GreenNode GetCurrentNode(int position)
+        private GreenNode? GetCurrentNode(int position)
         {
             Debug.Assert(_currentNode != null);
             var mappedPosition = MapNewPositionToOldTree(position);
@@ -218,7 +221,7 @@ namespace Microsoft.Language.Xml
             return _currentNode;
         }
 
-        private bool CanReuseNode(GreenNode node)
+        private bool CanReuseNode(GreenNode? node)
         {
             if (node == null)
                 return false;

--- a/src/Microsoft.Language.Xml/Classification/ClassifierVisitor.cs
+++ b/src/Microsoft.Language.Xml/Classification/ClassifierVisitor.cs
@@ -89,9 +89,9 @@ namespace Microsoft.Language.Xml
         private struct VisitState
         {
             public SyntaxNode node;
-            public XmlClassificationTypes[] childTypes;
+            public XmlClassificationTypes[]? childTypes;
             public int i;
-            public SyntaxNode child;
+            public SyntaxNode? child;
             public XmlClassificationTypes childType;
             public bool continueInsideForLoop;
         }
@@ -219,7 +219,7 @@ namespace Microsoft.Language.Xml
                 return 0;
             }
 
-            XmlClassificationTypes[] childTypes = null;
+            XmlClassificationTypes[]? childTypes = null;
             kindMap.TryGetValue(node.Kind, out childTypes);
 
             int visitedCount = 0;

--- a/src/Microsoft.Language.Xml/Comments/CommentUtilities.cs
+++ b/src/Microsoft.Language.Xml/Comments/CommentUtilities.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml.Comments
 {
     public static class CommentUtilities

--- a/src/Microsoft.Language.Xml/DiagnosticInfo.cs
+++ b/src/Microsoft.Language.Xml/DiagnosticInfo.cs
@@ -5,6 +5,9 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Resources;
 
+#pragma warning disable CS8603
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     /// <summary>
@@ -37,7 +40,7 @@ namespace Microsoft.Language.Xml
 
     public class DiagnosticInfo
     {
-        object[] parameters;
+        object[]? parameters;
 
         public ERRID ErrorID { get; }
         public DiagnosticSeverity Severity => DiagnosticSeverity.Error;

--- a/src/Microsoft.Language.Xml/InternalSyntax/GreenNode.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/GreenNode.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS8602
+#pragma warning disable CS8604
 
 namespace Microsoft.Language.Xml.InternalSyntax
 {
@@ -40,12 +44,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
             this.fullWidth = fullWidth;
         }
 
-        protected GreenNode(SyntaxKind kind, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+        protected GreenNode(SyntaxKind kind, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
             : this(kind, 0, diagnostics, annotations)
         {
         }
 
-        protected GreenNode(SyntaxKind kind, int fullWidth, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+        protected GreenNode(SyntaxKind kind, int fullWidth, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
             : this(kind, fullWidth)
         {
             if (diagnostics?.Length > 0)
@@ -63,7 +67,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        protected void AdjustWidth(GreenNode node)
+        protected void AdjustWidth(GreenNode? node)
         {
             this.fullWidth += node == null ? 0 : node.fullWidth;
         }
@@ -87,7 +91,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        internal abstract GreenNode GetSlot(int index);
+        internal abstract GreenNode? GetSlot(int index);
 
         // for slot counts >= byte.MaxValue
         protected virtual int GetSlotCount()
@@ -143,7 +147,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         internal virtual bool IsToken => false;
         internal virtual bool IsMissing => (flags & NodeFlags.IsMissing) != 0;
 
-        internal virtual GreenNode GetLeadingTrivia()
+        internal virtual GreenNode? GetLeadingTrivia()
         {
             return GetFirstTerminal()?.GetLeadingTrivia();
         }
@@ -155,7 +159,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 0;
         }
 
-        internal virtual GreenNode GetTrailingTrivia()
+        internal virtual GreenNode? GetTrailingTrivia()
         {
             return GetLastTerminal()?.GetTrailingTrivia();
         }
@@ -183,16 +187,16 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        public virtual GreenNode GetLeadingTriviaCore() { return null; }
-        public virtual GreenNode GetTrailingTriviaCore() { return null; }
+        public virtual GreenNode? GetLeadingTriviaCore() { return null; }
+        public virtual GreenNode? GetTrailingTriviaCore() { return null; }
 
-        internal GreenNode GetFirstTerminal()
+        internal GreenNode? GetFirstTerminal()
         {
-            GreenNode node = this;
+            GreenNode? node = this;
 
             do
             {
-                GreenNode firstChild = null;
+                GreenNode? firstChild = null;
                 for (int i = 0, n = node.SlotCount; i < n; i++)
                 {
                     var child = node.GetSlot(i);
@@ -208,13 +212,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node;
         }
 
-        internal GreenNode GetLastTerminal()
+        internal GreenNode? GetLastTerminal()
         {
-            GreenNode node = this;
+            GreenNode? node = this;
 
             do
             {
-                GreenNode lastChild = null;
+                GreenNode? lastChild = null;
                 for (int i = node.SlotCount - 1; i >= 0; i--)
                 {
                     var child = node.GetSlot(i);
@@ -230,13 +234,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node;
         }
 
-        internal GreenNode GetLastNonmissingTerminal()
+        internal GreenNode? GetLastNonmissingTerminal()
         {
-            GreenNode node = this;
+            GreenNode? node = this;
 
             do
             {
-                GreenNode nonmissingChild = null;
+                GreenNode? nonmissingChild = null;
                 for (int i = node.SlotCount - 1; i >= 0; i--)
                 {
                     var child = node.GetSlot(i);
@@ -253,7 +257,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node;
         }
 
-        public virtual GreenNode CreateList(IEnumerable<GreenNode> nodes, bool alwaysCreateListNode = false)
+        public virtual GreenNode? CreateList(IEnumerable<GreenNode>? nodes, bool alwaysCreateListNode = false)
         {
             if (nodes == null)
             {
@@ -289,7 +293,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return CreateRed(null, 0);
         }
 
-        internal abstract SyntaxNode CreateRed(SyntaxNode parent, int position);
+        internal abstract SyntaxNode CreateRed(SyntaxNode? parent, int position);
 
         public virtual string ToFullString()
         {
@@ -347,7 +351,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         {
             if (this.ContainsDiagnostics)
             {
-                DiagnosticInfo[] diags;
+                DiagnosticInfo[]? diags;
                 if (diagnosticsTable.TryGetValue(this, out diags))
                 {
                     return diags;
@@ -384,7 +388,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return SetDiagnostics(errorInfos);
         }
 
-        internal abstract GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics);
+        internal abstract GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics);
         #endregion
 
         #region Annotations
@@ -505,7 +509,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         {
             if (this.ContainsAnnotations)
             {
-                SyntaxAnnotation[] annotations;
+                SyntaxAnnotation[]? annotations;
                 if (annotationsTable.TryGetValue(this, out annotations))
                 {
                     System.Diagnostics.Debug.Assert(annotations.Length != 0, "we should return nonempty annotations or NoAnnotations");
@@ -565,7 +569,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 this.GetSlot(0) == child1;
         }
 
-        internal bool IsCacheEquivalent(SyntaxKind kind, NodeFlags flags, GreenNode child1, GreenNode child2)
+        internal bool IsCacheEquivalent(SyntaxKind kind, NodeFlags flags, GreenNode? child1, GreenNode? child2)
         {
             Debug.Assert(this.IsCacheable);
 

--- a/src/Microsoft.Language.Xml/InternalSyntax/GreenNodeExtensions.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/GreenNodeExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
 {
     internal static class GreenNodeExtensions
     {
-        internal static TSyntax AddLeadingTrivia<TSyntax>(this TSyntax node, InternalSyntax.SyntaxList<GreenNode> trivia) where TSyntax : GreenNode
+        internal static TSyntax AddLeadingTrivia<TSyntax>(this TSyntax? node, InternalSyntax.SyntaxList<GreenNode> trivia) where TSyntax : GreenNode
         {
             if (node == null)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return string.IsNullOrEmpty(token.Text);
         }
 
-        internal static TSyntax AddLeadingSyntax<TSyntax>(this TSyntax node, GreenNode unexpected) where TSyntax : GreenNode
+        internal static TSyntax AddLeadingSyntax<TSyntax>(this TSyntax node, GreenNode? unexpected) where TSyntax : GreenNode
         {
             if (unexpected != null) {
                 var trivia = CreateSkippedTrivia(unexpected,
@@ -159,7 +159,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node.AddLeadingSyntax(unexpected.Node);
         }
 
-        internal static TSyntax AddLeadingSyntax<TSyntax>(this TSyntax node, GreenNode unexpected, ERRID errorId) where TSyntax : GreenNode
+        internal static TSyntax AddLeadingSyntax<TSyntax>(this TSyntax node, GreenNode? unexpected, ERRID errorId) where TSyntax : GreenNode
         {
             var diagnostic = ErrorFactory.ErrorInfo(errorId);
             if (unexpected != null)
@@ -205,7 +205,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node.AddTrailingSyntax(unexpected.Node);
         }
 
-        internal static TSyntax AddTrailingSyntax<TSyntax>(this TSyntax node, GreenNode unexpected) where TSyntax : GreenNode
+        internal static TSyntax AddTrailingSyntax<TSyntax>(this TSyntax node, GreenNode? unexpected) where TSyntax : GreenNode
         {
             if (unexpected != null)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return node;
         }
 
-        internal static TSyntax AddTrailingTrivia<TSyntax>(this TSyntax node, InternalSyntax.SyntaxList<GreenNode> trivia) where TSyntax : GreenNode
+        internal static TSyntax AddTrailingTrivia<TSyntax>(this TSyntax? node, InternalSyntax.SyntaxList<GreenNode> trivia) where TSyntax : GreenNode
         {
             if (node == null)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         //   "addDiagnostic", if not Nothing, is added as a diagnostics
         //   "addDiagnosticsToFirstTokenOnly" means that "addDiagnostics" is attached only to the first token, otherwise
         //    it is attached to all tokens.
-        private static InternalSyntax.SyntaxList<GreenNode> CreateSkippedTrivia(GreenNode node, bool preserveDiagnostics, bool addDiagnosticToFirstTokenOnly, DiagnosticInfo addDiagnostic)
+        private static InternalSyntax.SyntaxList<GreenNode> CreateSkippedTrivia(GreenNode node, bool preserveDiagnostics, bool addDiagnosticToFirstTokenOnly, DiagnosticInfo? addDiagnostic)
         {
             if (node.Kind == SyntaxKind.SkippedTokensTrivia)
             {
@@ -291,7 +291,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return skippedTriviaBuilder.GetTriviaList();
         }
 
-        internal static void CollectConstituentTokensAndDiagnostics(this GreenNode node, InternalSyntax.SyntaxListBuilder<SyntaxToken.Green> tokenListBuilder, IList<DiagnosticInfo> nonTokenDiagnostics)
+        internal static void CollectConstituentTokensAndDiagnostics(this GreenNode? node, InternalSyntax.SyntaxListBuilder<SyntaxToken.Green> tokenListBuilder, IList<DiagnosticInfo> nonTokenDiagnostics)
         {
             if (node == null)
                 return;
@@ -322,7 +322,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        internal static bool ContainsWhitespaceTrivia(this GreenNode node)
+        internal static bool ContainsWhitespaceTrivia(this GreenNode? node)
         {
             if (node == null)
             {
@@ -344,7 +344,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
 
         // In order to handle creating SkippedTokens trivia correctly, we need to know if any structured
         // trivia is present in a trivia list (because structured trivia can't contain structured trivia).
-        internal static bool TriviaListContainsStructuredTrivia(this GreenNode triviaList)
+        internal static bool TriviaListContainsStructuredTrivia(this GreenNode? triviaList)
         {
             if (triviaList == null)
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        public static TNode WithAdditionalAnnotationsGreen<TNode>(this TNode node, IEnumerable<SyntaxAnnotation> annotations) where TNode : GreenNode
+        public static TNode WithAdditionalAnnotationsGreen<TNode>(this TNode node, IEnumerable<SyntaxAnnotation>? annotations) where TNode : GreenNode
         {
             var existingAnnotations = node.GetAnnotations();
 
@@ -408,7 +408,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        public static TNode WithoutAnnotationsGreen<TNode>(this TNode node, IEnumerable<SyntaxAnnotation> annotations) where TNode : GreenNode
+        public static TNode WithoutAnnotationsGreen<TNode>(this TNode node, IEnumerable<SyntaxAnnotation>? annotations) where TNode : GreenNode
         {
             var existingAnnotations = node.GetAnnotations();
 

--- a/src/Microsoft.Language.Xml/InternalSyntax/SeparatedSyntaxList.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SeparatedSyntaxList.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        internal GreenNode Node => _list.Node;
+        internal GreenNode? Node => _list.Node;
 
         public int Count
         {
@@ -86,7 +86,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return _list == other._list;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is SeparatedSyntaxList<TNode>) && Equals((SeparatedSyntaxList<TNode>)obj);
         }

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxFactory.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxFactory.cs
@@ -6,18 +6,18 @@ namespace Microsoft.Language.Xml.InternalSyntax
     {
         #region Nodes
         internal static XmlDocumentSyntax.Green XmlDocument(
-            XmlDeclarationSyntax.Green prologue,
+            XmlDeclarationSyntax.Green? prologue,
             SyntaxList<GreenNode> precedingMisc,
             XmlNodeSyntax.Green body,
             SyntaxList<GreenNode> followingMisc,
-            SkippedTokensTriviaSyntax.Green skippedTokens,
+            SkippedTokensTriviaSyntax.Green? skippedTokens,
             SyntaxToken.Green eof)
         {
             return new XmlDocumentSyntax.Green(prologue, precedingMisc.Node, body, followingMisc.Node, skippedTokens, eof);
         }
 
         internal static XmlDocumentSyntax.Green XmlDocument(
-            XmlDeclarationSyntax.Green prologue,
+            XmlDeclarationSyntax.Green? prologue,
             GreenNode precedingMisc,
             XmlNodeSyntax.Green body,
             GreenNode followingMisc,
@@ -27,12 +27,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return new XmlDocumentSyntax.Green(prologue, precedingMisc, body, followingMisc, skippedTokens, eof);
         }
 
-        internal static XmlNodeSyntax.Green XmlElement(XmlElementStartTagSyntax.Green startElement, GreenNode content, XmlElementEndTagSyntax.Green endElement)
+        internal static XmlNodeSyntax.Green XmlElement(XmlElementStartTagSyntax.Green? startElement, GreenNode? content, XmlElementEndTagSyntax.Green endElement)
         {
             return new XmlElementSyntax.Green(startElement, content, endElement);
         }
 
-        internal static XmlNodeSyntax.Green XmlEmptyElement(PunctuationSyntax.Green lessThanToken, XmlNameSyntax.Green name, GreenNode attributes, PunctuationSyntax.Green slashGreaterThanToken)
+        internal static XmlNodeSyntax.Green XmlEmptyElement(PunctuationSyntax.Green lessThanToken, XmlNameSyntax.Green name, GreenNode? attributes, PunctuationSyntax.Green slashGreaterThanToken)
         {
             return new XmlEmptyElementSyntax.Green(lessThanToken, name, attributes, slashGreaterThanToken);
         }
@@ -40,7 +40,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         internal static XmlElementStartTagSyntax.Green XmlElementStartTag(
             PunctuationSyntax.Green lessThanToken,
             XmlNameSyntax.Green name,
-            GreenNode attributes,
+            GreenNode? attributes,
             PunctuationSyntax.Green greaterThanToken)
         {
             return new XmlElementStartTagSyntax.Green(lessThanToken, name, attributes, greaterThanToken);
@@ -70,7 +70,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return result;
         }
 
-        internal static XmlNameSyntax.Green XmlName(XmlPrefixSyntax.Green prefix, XmlNameTokenSyntax.Green localName)
+        internal static XmlNameSyntax.Green XmlName(XmlPrefixSyntax.Green? prefix, XmlNameTokenSyntax.Green localName)
         {
             int hash;
             var cached = SyntaxNodeCache.TryGetNode(SyntaxKind.XmlName, prefix, localName, out hash);
@@ -82,12 +82,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return result;
         }
 
-        internal static XmlDeclarationOptionSyntax.Green XmlDeclarationOption(XmlNameTokenSyntax.Green name, PunctuationSyntax.Green equals, XmlStringSyntax.Green value)
+        internal static XmlDeclarationOptionSyntax.Green XmlDeclarationOption(XmlNameTokenSyntax.Green? name, PunctuationSyntax.Green? equals, XmlStringSyntax.Green? value)
         {
             return new XmlDeclarationOptionSyntax.Green(name, equals, value);
         }
 
-        internal static XmlDeclarationSyntax.Green XmlDeclaration(PunctuationSyntax.Green lessThanQuestionToken, SyntaxToken.Green xmlKeyword, XmlDeclarationOptionSyntax.Green version, XmlDeclarationOptionSyntax.Green encoding, XmlDeclarationOptionSyntax.Green standalone, PunctuationSyntax.Green questionGreaterThanToken)
+        internal static XmlDeclarationSyntax.Green XmlDeclaration(PunctuationSyntax.Green lessThanQuestionToken, SyntaxToken.Green? xmlKeyword, XmlDeclarationOptionSyntax.Green? version, XmlDeclarationOptionSyntax.Green? encoding, XmlDeclarationOptionSyntax.Green? standalone, PunctuationSyntax.Green? questionGreaterThanToken)
         {
             return new XmlDeclarationSyntax.Green(lessThanQuestionToken, xmlKeyword, version, encoding, standalone, questionGreaterThanToken);
         }
@@ -97,7 +97,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return new XmlTextSyntax.Green(textTokens.Node);
         }
 
-        internal static XmlStringSyntax.Green XmlString(PunctuationSyntax.Green startQuoteToken, GreenNode textTokens, PunctuationSyntax.Green endQuoteToken)
+        internal static XmlStringSyntax.Green XmlString(PunctuationSyntax.Green startQuoteToken, GreenNode? textTokens, PunctuationSyntax.Green endQuoteToken)
         {
             return new XmlStringSyntax.Green(startQuoteToken, textTokens, endQuoteToken);
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return new SyntaxTrivia.Green(SyntaxKind.EndOfLineTrivia, text);
         }
 
-        internal static XmlNameTokenSyntax.Green XmlNameToken(string text, GreenNode precedingTrivia, GreenNode followingTrivia)
+        internal static XmlNameTokenSyntax.Green XmlNameToken(string text, GreenNode? precedingTrivia, GreenNode? followingTrivia)
         {
             return new XmlNameTokenSyntax.Green(text, precedingTrivia, followingTrivia);
         }

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxList.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxList.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         {
         }
 
-        internal SyntaxList(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+        internal SyntaxList(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
             : base(SyntaxKind.List, diagnostics, annotations)
         {
         }
@@ -134,7 +134,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 _child1 = child1;
             }
 
-            internal WithTwoChildren(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, GreenNode child0, GreenNode child1)
+            internal WithTwoChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations, GreenNode child0, GreenNode child1)
                 : base(diagnostics, annotations)
             {
                 this.SlotCount = 2;
@@ -144,7 +144,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 _child1 = child1;
             }
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -163,12 +163,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 array[offset + 1].Value = _child1;
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position)
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position)
             {
                 return new Xml.SyntaxList.WithTwoChildren(this, parent, position);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] errors)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
             {
                 return new WithTwoChildren(errors, this.GetAnnotations(), _child0, _child1);
             }
@@ -196,7 +196,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 _child2 = child2;
             }
 
-            internal WithThreeChildren(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, GreenNode child0, GreenNode child1, GreenNode child2)
+            internal WithThreeChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations, GreenNode child0, GreenNode child1, GreenNode child2)
                 : base(diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -208,7 +208,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 _child2 = child2;
             }
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -230,12 +230,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 array[offset + 2].Value = _child2;
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position)
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position)
             {
                 return new Xml.SyntaxList.WithThreeChildren(this, parent, position);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] errors)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
             {
                 return new WithThreeChildren(errors, this.GetAnnotations(), _child0, _child1, _child2);
             }
@@ -256,7 +256,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 this.InitializeChildren();
             }
 
-            internal WithManyChildrenBase(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children)
+            internal WithManyChildrenBase(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children)
                 : base(diagnostics, annotations)
             {
                 this.children = children;
@@ -296,7 +296,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 Array.Copy(this.children, 0, array, offset, this.children.Length);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position)
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position)
             {
                 return new Xml.SyntaxList.WithManyChildren(this, parent, position);
             }
@@ -309,12 +309,12 @@ namespace Microsoft.Language.Xml.InternalSyntax
             {
             }
 
-            internal WithManyChildren(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children)
+            internal WithManyChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children)
                 : base(diagnostics, annotations, children)
             {
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] errors)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
             {
                 return new WithManyChildren(errors, this.GetAnnotations(), children);
             }
@@ -335,7 +335,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 _childOffsets = CalculateOffsets(children);
             }
 
-            internal WithLotsOfChildren(DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children, int[] childOffsets)
+            internal WithLotsOfChildren(DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations, ArrayElement<GreenNode>[] children, int[] childOffsets)
                 : base(diagnostics, annotations, children)
             {
                 _childOffsets = childOffsets;
@@ -374,7 +374,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 return childOffsets;
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] errors)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? errors)
             {
                 return new WithLotsOfChildren(errors, this.GetAnnotations(), children, _childOffsets);
             }

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxListBuilder.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxListBuilder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 
+#pragma warning disable CS8625
+
 namespace Microsoft.Language.Xml.InternalSyntax
 {
     internal class SyntaxListBuilder
@@ -36,7 +38,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             }
         }
 
-        public void Add(GreenNode item)
+        public void Add(GreenNode? item)
         {
             if (item == null) return;
 
@@ -165,7 +167,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return array;
         }
 
-        internal GreenNode ToListNode()
+        internal GreenNode? ToListNode()
         {
             switch (this.Count)
             {

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxListBuilder`1.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxListBuilder`1.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return _builder.ToList<TNode>();
         }
 
-        public GreenNode ToListNode()
+        public GreenNode? ToListNode()
         {
             return _builder.ToListNode();
         }

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxList`1.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxList`1.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Language.Xml.InternalSyntax
     internal readonly struct SyntaxList<TNode>
         where TNode : GreenNode
     {
-        private readonly GreenNode _node;
+        private readonly GreenNode? _node;
 
-        public SyntaxList(GreenNode node)
+        public SyntaxList(GreenNode? node)
         {
             this._node = node;
         }
 
-        public GreenNode Node
+        public GreenNode? Node
         {
             get
             {
-                return ((GreenNode)this._node);
+                return ((GreenNode?)this._node);
             }
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return !(left._node == right._node);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is SyntaxList<TNode> && (this._node == ((SyntaxList<TNode>)obj)._node));
         }
@@ -132,7 +132,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return new SeparatedSyntaxList<TOther>(new SyntaxList<TOther>(this._node));
         }*/
 
-        public static implicit operator SyntaxList<TNode>(TNode node)
+        public static implicit operator SyntaxList<TNode>(TNode? node)
         {
             return new SyntaxList<TNode>(node);
         }

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxRewriter.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxRewriter.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
 
+#pragma warning disable CS8602
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml.InternalSyntax
 {
     internal class SyntaxRewriter : SyntaxVisitor
@@ -49,8 +52,8 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 var item = list[i];
                 var visitedItem = this.Visit(item);
 
-                GreenNode separator = null;
-                GreenNode visitedSeparator = null;
+                GreenNode? separator = null;
+                GreenNode? visitedSeparator = null;
 
                 if (i < separatorCount)
                 {
@@ -104,7 +107,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlDocument(XmlDocumentSyntax.Green node)
         {
             bool anyChanges = false;
-            var newDeclaration = ((XmlDeclarationSyntax.Green)Visit(node.Prologue));
+            var newDeclaration = ((XmlDeclarationSyntax.Green?)Visit(node.Prologue));
             if (node.Prologue != newDeclaration)
             {
                 anyChanges = true;
@@ -116,7 +119,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newRoot = ((XmlNodeSyntax.Green)Visit(node.Body));
+            var newRoot = ((XmlNodeSyntax.Green?)Visit(node.Body));
             if (node.Body != newRoot)
             {
                 anyChanges = true;
@@ -159,37 +162,37 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlDeclaration(XmlDeclarationSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanQuestionToken = ((PunctuationSyntax.Green)Visit(node.LessThanQuestionToken));
+            var newLessThanQuestionToken = ((PunctuationSyntax.Green?)Visit(node.LessThanQuestionToken));
             if (node.LessThanQuestionToken != newLessThanQuestionToken)
             {
                 anyChanges = true;
             }
 
-            var newXmlKeyword = ((KeywordSyntax.Green)Visit(node.XmlKeyword));
+            var newXmlKeyword = ((KeywordSyntax.Green?)Visit(node.XmlKeyword));
             if (node.XmlKeyword != newXmlKeyword)
             {
                 anyChanges = true;
             }
 
-            var newVersion = ((XmlDeclarationOptionSyntax.Green)Visit(node.Version));
+            var newVersion = ((XmlDeclarationOptionSyntax.Green?)Visit(node.Version));
             if (node.Version != newVersion)
             {
                 anyChanges = true;
             }
 
-            var newEncoding = ((XmlDeclarationOptionSyntax.Green)Visit(node.Encoding));
+            var newEncoding = ((XmlDeclarationOptionSyntax.Green?)Visit(node.Encoding));
             if (node.Encoding != newEncoding)
             {
                 anyChanges = true;
             }
 
-            var newStandalone = ((XmlDeclarationOptionSyntax.Green)Visit(node.Standalone));
+            var newStandalone = ((XmlDeclarationOptionSyntax.Green?)Visit(node.Standalone));
             if (node.Standalone != newStandalone)
             {
                 anyChanges = true;
             }
 
-            var newQuestionGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.QuestionGreaterThanToken));
+            var newQuestionGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.QuestionGreaterThanToken));
             if (node.QuestionGreaterThanToken != newQuestionGreaterThanToken)
             {
                 anyChanges = true;
@@ -214,19 +217,19 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlDeclarationOption(XmlDeclarationOptionSyntax.Green node)
         {
             bool anyChanges = false;
-            var newName = ((XmlNameTokenSyntax.Green)Visit(node.Name));
+            var newName = ((XmlNameTokenSyntax.Green?)Visit(node.Name));
             if (node.Name != newName)
             {
                 anyChanges = true;
             }
 
-            var newEquals = ((PunctuationSyntax.Green)Visit(node.Equals));
+            var newEquals = ((PunctuationSyntax.Green?)Visit(node.Equals));
             if (node.Equals != newEquals)
             {
                 anyChanges = true;
             }
 
-            var newValue = ((XmlStringSyntax.Green)Visit(node.Value));
+            var newValue = ((XmlStringSyntax.Green?)Visit(node.Value));
             if (node.Value != newValue)
             {
                 anyChanges = true;
@@ -245,7 +248,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlElement(XmlElementSyntax.Green node)
         {
             bool anyChanges = false;
-            var newStartTag = ((XmlElementStartTagSyntax.Green)Visit(node.StartTag));
+            var newStartTag = ((XmlElementStartTagSyntax.Green?)Visit(node.StartTag));
             if (node.StartTag != newStartTag)
             {
                 anyChanges = true;
@@ -257,7 +260,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newEndTag = ((XmlElementEndTagSyntax.Green)Visit(node.EndTag));
+            var newEndTag = ((XmlElementEndTagSyntax.Green?)Visit(node.EndTag));
             if (node.EndTag != newEndTag)
             {
                 anyChanges = true;
@@ -295,13 +298,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlElementStartTag(XmlElementStartTagSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanToken = ((PunctuationSyntax.Green)Visit(node.LessThanToken));
+            var newLessThanToken = ((PunctuationSyntax.Green?)Visit(node.LessThanToken));
             if (node.LessThanToken != newLessThanToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax.Green)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax.Green?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
@@ -313,7 +316,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.GreaterThanToken));
+            var newGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.GreaterThanToken));
             if (node.GreaterThanToken != newGreaterThanToken)
             {
                 anyChanges = true;
@@ -332,19 +335,19 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlElementEndTag(XmlElementEndTagSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanSlashToken = ((PunctuationSyntax.Green)Visit(node.LessThanSlashToken));
+            var newLessThanSlashToken = ((PunctuationSyntax.Green?)Visit(node.LessThanSlashToken));
             if (node.LessThanSlashToken != newLessThanSlashToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax.Green)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax.Green?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
             }
 
-            var newGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.GreaterThanToken));
+            var newGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.GreaterThanToken));
             if (node.GreaterThanToken != newGreaterThanToken)
             {
                 anyChanges = true;
@@ -363,13 +366,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlEmptyElement(XmlEmptyElementSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanToken = ((PunctuationSyntax.Green)Visit(node.LessThanToken));
+            var newLessThanToken = ((PunctuationSyntax.Green?)Visit(node.LessThanToken));
             if (node.LessThanToken != newLessThanToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax.Green)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax.Green?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
@@ -381,7 +384,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newSlashGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.SlashGreaterThanToken));
+            var newSlashGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.SlashGreaterThanToken));
             if (node.SlashGreaterThanToken != newSlashGreaterThanToken)
             {
                 anyChanges = true;
@@ -400,19 +403,19 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlAttribute(XmlAttributeSyntax.Green node)
         {
             bool anyChanges = false;
-            var newName = ((XmlNameSyntax.Green)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax.Green?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
             }
 
-            var newEqualsToken = ((PunctuationSyntax.Green)Visit(node.Equals));
+            var newEqualsToken = ((PunctuationSyntax.Green?)Visit(node.Equals));
             if (node.Equals != newEqualsToken)
             {
                 anyChanges = true;
             }
 
-            var newValue = ((XmlNodeSyntax.Green)Visit(node.ValueNode));
+            var newValue = ((XmlNodeSyntax.Green?)Visit(node.ValueNode));
             if (node.ValueNode != newValue)
             {
                 anyChanges = true;
@@ -431,7 +434,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlString(XmlStringSyntax.Green node)
         {
             bool anyChanges = false;
-            var newStartQuoteToken = ((PunctuationSyntax.Green)Visit(node.StartQuoteToken));
+            var newStartQuoteToken = ((PunctuationSyntax.Green?)Visit(node.StartQuoteToken));
             if (node.StartQuoteToken != newStartQuoteToken)
             {
                 anyChanges = true;
@@ -443,7 +446,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newEndQuoteToken = ((PunctuationSyntax.Green)Visit(node.EndQuoteToken));
+            var newEndQuoteToken = ((PunctuationSyntax.Green?)Visit(node.EndQuoteToken));
             if (node.EndQuoteToken != newEndQuoteToken)
             {
                 anyChanges = true;
@@ -462,13 +465,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlName(XmlNameSyntax.Green node)
         {
             bool anyChanges = false;
-            var newPrefix = ((XmlPrefixSyntax.Green)Visit(node.Prefix));
+            var newPrefix = ((XmlPrefixSyntax.Green?)Visit(node.Prefix));
             if (node.Prefix != newPrefix)
             {
                 anyChanges = true;
             }
 
-            var newLocalName = ((XmlNameTokenSyntax.Green)Visit(node.LocalName));
+            var newLocalName = ((XmlNameTokenSyntax.Green?)Visit(node.LocalName));
             if (node.LocalName != newLocalName)
             {
                 anyChanges = true;
@@ -512,7 +515,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlComment(XmlCommentSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanExclamationMinusMinusToken = ((PunctuationSyntax.Green)Visit(node.BeginComment));
+            var newLessThanExclamationMinusMinusToken = ((PunctuationSyntax.Green?)Visit(node.BeginComment));
             if (node.BeginComment != newLessThanExclamationMinusMinusToken)
             {
                 anyChanges = true;
@@ -524,7 +527,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newMinusMinusGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.EndComment));
+            var newMinusMinusGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.EndComment));
             if (node.EndComment != newMinusMinusGreaterThanToken)
             {
                 anyChanges = true;
@@ -543,13 +546,13 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlProcessingInstruction(XmlProcessingInstructionSyntax.Green node)
         {
             bool anyChanges = false;
-            var newLessThanQuestionToken = ((PunctuationSyntax.Green)Visit(node.LessThanQuestionToken));
+            var newLessThanQuestionToken = ((PunctuationSyntax.Green?)Visit(node.LessThanQuestionToken));
             if (node.LessThanQuestionToken != newLessThanQuestionToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameTokenSyntax.Green)Visit(node.Name));
+            var newName = ((XmlNameTokenSyntax.Green?)Visit(node.Name));
             if (node.Name != newName)
             {
                 anyChanges = true;
@@ -561,7 +564,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newQuestionGreaterThanToken = ((PunctuationSyntax.Green)Visit(node.QuestionGreaterThanToken));
+            var newQuestionGreaterThanToken = ((PunctuationSyntax.Green?)Visit(node.QuestionGreaterThanToken));
             if (node.QuestionGreaterThanToken != newQuestionGreaterThanToken)
             {
                 anyChanges = true;
@@ -580,7 +583,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
         public override GreenNode VisitXmlCDataSection(XmlCDataSectionSyntax.Green node)
         {
             bool anyChanges = false;
-            var newBeginCDataToken = ((PunctuationSyntax.Green)Visit(node.BeginCData));
+            var newBeginCDataToken = ((PunctuationSyntax.Green?)Visit(node.BeginCData));
             if (node.BeginCData != newBeginCDataToken)
             {
                 anyChanges = true;
@@ -592,7 +595,7 @@ namespace Microsoft.Language.Xml.InternalSyntax
                 anyChanges = true;
             }
 
-            var newEndCDataToken = ((PunctuationSyntax.Green)Visit(node.EndCData));
+            var newEndCDataToken = ((PunctuationSyntax.Green?)Visit(node.EndCData));
             if (node.EndCData != newEndCDataToken)
             {
                 anyChanges = true;

--- a/src/Microsoft.Language.Xml/InternalSyntax/SyntaxVisitor.cs
+++ b/src/Microsoft.Language.Xml/InternalSyntax/SyntaxVisitor.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Language.Xml.InternalSyntax
 {
     internal abstract partial class SyntaxVisitor
     {
-        public virtual GreenNode Visit(GreenNode node)
+        [return: NotNullIfNotNull(nameof(node))]
+        public virtual GreenNode? Visit(GreenNode? node)
         {
             if (node != null)
             {
@@ -109,7 +111,8 @@ namespace Microsoft.Language.Xml.InternalSyntax
             return list;
         }
 
-        public virtual SyntaxToken.Green VisitSyntaxToken(SyntaxToken.Green token)
+        [return: NotNullIfNotNull(nameof(token))]
+        public virtual SyntaxToken.Green? VisitSyntaxToken(SyntaxToken.Green? token)
         {
             return token;
         }

--- a/src/Microsoft.Language.Xml/Microsoft.Language.Xml.csproj
+++ b/src/Microsoft.Language.Xml/Microsoft.Language.Xml.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.Language.Xml</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NBGV_DoNotEmitNonVersionCustomAttributes>true</NBGV_DoNotEmitNonVersionCustomAttributes>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.84" PrivateAssets="all" />

--- a/src/Microsoft.Language.Xml/PooledStringBuilder.cs
+++ b/src/Microsoft.Language.Xml/PooledStringBuilder.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Text;
 
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     /// <summary>
@@ -71,7 +73,7 @@ namespace Microsoft.Language.Xml
         // if someone needs to create a private pool;
         public static ObjectPool<PooledStringBuilder> CreatePool()
         {
-            ObjectPool<PooledStringBuilder> pool = null;
+            ObjectPool<PooledStringBuilder>? pool = null;
             pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), 32);
             return pool;
         }

--- a/src/Microsoft.Language.Xml/Scanner.cs
+++ b/src/Microsoft.Language.Xml/Scanner.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Language.Xml
             return false;
         }
 
-        internal virtual GreenNode GetCurrentSyntaxNode()
+        internal virtual GreenNode? GetCurrentSyntaxNode()
         {
             return null;
         }
@@ -68,7 +68,7 @@ namespace Microsoft.Language.Xml
             return tk;
         }
 
-        internal SyntaxToken.Green PrevToken
+        internal SyntaxToken.Green? PrevToken
         {
             get
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Language.Xml
             _currentToken = new ScannerToken(_lineBufferOffset, _endOfTerminatorTrivia, null, state);
         }
 
-        internal SyntaxToken.Green PeekNextToken(ScannerState state)
+        internal SyntaxToken.Green? PeekNextToken(ScannerState state)
         {
             if (_tokens.Count > 0)
             {
@@ -164,7 +164,7 @@ namespace Microsoft.Language.Xml
 
         private SyntaxToken.Green GetScannerToken(ScannerState state)
         {
-            SyntaxToken.Green token = null;
+            SyntaxToken.Green? token = null;
 
             switch (state)
             {
@@ -858,7 +858,7 @@ namespace Microsoft.Language.Xml
             bool isFirst = true;
             ERRID err = ERRID.ERR_None;
             int errUnicode = 0;
-            string errChar = null;
+            string? errChar = null;
 
             // TODO - Fix ScanXmlNCName to conform to XML spec instead of old loose scanning.
             while (CanGetCharAtOffset(Here))
@@ -957,7 +957,7 @@ namespace Microsoft.Language.Xml
             return MissingToken(precedingTrivia, SyntaxKind.XmlNameToken);
         }
 
-        private XmlNameTokenSyntax.Green XmlMakeXmlNCNameToken(GreenNode precedingTrivia, int tokenWidth)
+        private XmlNameTokenSyntax.Green XmlMakeXmlNCNameToken(GreenNode? precedingTrivia, int tokenWidth)
         {
             Debug.Assert(tokenWidth > 0);
             var text = GetText(tokenWidth);
@@ -1242,7 +1242,7 @@ namespace Microsoft.Language.Xml
 
             AdvanceChar();
 
-            GreenNode followingTrivia = null;
+            GreenNode? followingTrivia = null;
             if (!isOpening)
             {
                 var ws = ScanXmlWhitespace();
@@ -1268,7 +1268,7 @@ namespace Microsoft.Language.Xml
 
             AdvanceChar();
 
-            GreenNode followingTrivia = null;
+            GreenNode? followingTrivia = null;
             if (!isOpening)
             {
                 var ws = ScanXmlWhitespace();
@@ -1565,7 +1565,7 @@ namespace Microsoft.Language.Xml
                         var result = ScanXmlCharRef(ref Here);
                         if (result.Length != 0)
                         {
-                            string value = null;
+                            string? value = null;
                             if (result.Length == 1)
                             {
                                 value = Intern(result.Char1);
@@ -2220,7 +2220,7 @@ namespace Microsoft.Language.Xml
 
         protected readonly struct ScannerToken
         {
-            internal ScannerToken(int lineBufferOffset, int endOfTerminatorTrivia, SyntaxToken.Green token, ScannerState state)
+            internal ScannerToken(int lineBufferOffset, int endOfTerminatorTrivia, SyntaxToken.Green? token, ScannerState state)
             {
                 this.Position = lineBufferOffset;
                 this.EndOfTerminatorTrivia = endOfTerminatorTrivia;
@@ -2228,12 +2228,12 @@ namespace Microsoft.Language.Xml
                 this.State = state;
             }
 
-            internal ScannerToken With(ScannerState state, SyntaxToken.Green token)
+            internal ScannerToken With(ScannerState state, SyntaxToken.Green? token)
             {
                 return new ScannerToken(this.Position, this.EndOfTerminatorTrivia, token, state);
             }
 
-            internal readonly SyntaxToken.Green InnerTokenObject;
+            internal readonly SyntaxToken.Green? InnerTokenObject;
             internal readonly int Position;
             internal readonly int EndOfTerminatorTrivia;
             internal readonly ScannerState State;

--- a/src/Microsoft.Language.Xml/Structure/INamedXmlNode.cs
+++ b/src/Microsoft.Language.Xml/Structure/INamedXmlNode.cs
@@ -4,6 +4,6 @@ namespace Microsoft.Language.Xml
 {
     public interface INamedXmlNode
     {
-        string Name { get; }
+        string? Name { get; }
     }
 }

--- a/src/Microsoft.Language.Xml/Structure/IXmlElement.cs
+++ b/src/Microsoft.Language.Xml/Structure/IXmlElement.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Language.Xml
     {
         int Start { get; }
         int FullWidth { get; }
-        string Name { get; }
+        string? Name { get; }
         string Value { get; }
-        IXmlElement Parent { get; }
+        IXmlElement? Parent { get; }
         IEnumerable<IXmlElement> Elements { get; }
         IEnumerable<KeyValuePair<string, string>> Attributes { get; }
-        string this[string attributeName] { get; }
+        string? this[string attributeName] { get; }
         IXmlElementSyntax AsSyntaxElement { get; }
     }
 }

--- a/src/Microsoft.Language.Xml/Syntax/BadTokenSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/BadTokenSyntax.cs
@@ -10,21 +10,21 @@ namespace Microsoft.Language.Xml
         {
             public SyntaxSubKind SubKind { get; }
 
-            internal Green(SyntaxSubKind subKind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(SyntaxSubKind subKind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(SyntaxKind.BadToken, name, leadingTrivia, trailingTrivia)
             {
                 SubKind = subKind;
             }
 
-            internal Green(SyntaxSubKind subKind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxSubKind subKind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.BadToken, name, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
                 SubKind = subKind;
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new BadTokenSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new BadTokenSyntax(this, parent, position);
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(SubKind, Text, LeadingTrivia, TrailingTrivia, diagnostics, GetAnnotations());
             }
@@ -39,7 +39,7 @@ namespace Microsoft.Language.Xml
 
         public SyntaxSubKind SubKind => GreenNode.SubKind;
 
-        internal BadTokenSyntax(Green green, SyntaxNode parent, int position)
+        internal BadTokenSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 

--- a/src/Microsoft.Language.Xml/Syntax/ChildSyntaxList.cs
+++ b/src/Microsoft.Language.Xml/Syntax/ChildSyntaxList.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace Microsoft.Language.Xml
 {
+    using System.Diagnostics.CodeAnalysis;
     using InternalSyntax;
 
     public readonly struct ChildSyntaxList : IEquatable<ChildSyntaxList>, IReadOnlyList<SyntaxNode>
@@ -86,7 +87,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         internal static SyntaxNode ItemInternal(SyntaxNode node, int index)
         {
-            GreenNode greenChild;
+            GreenNode? greenChild;
             var green = node.GreenNode;
             var idx = index;
             var slotIndex = 0;
@@ -184,7 +185,7 @@ namespace Microsoft.Language.Xml
             int slot;
             for (slot = 0; ; slot++)
             {
-                GreenNode greenChild = green.GetSlot(slot);
+                GreenNode? greenChild = green.GetSlot(slot);
                 if (greenChild != null)
                 {
                     var endPosition = position + greenChild.FullWidth;
@@ -247,9 +248,9 @@ namespace Microsoft.Language.Xml
         /// internal indexer that does not verify index.
         /// Used when caller has already ensured that index is within bounds.
         /// </summary>
-        internal static SyntaxNode ItemInternalAsNode(SyntaxNode node, int index)
+        internal static SyntaxNode? ItemInternalAsNode(SyntaxNode node, int index)
         {
-            GreenNode greenChild;
+            GreenNode? greenChild;
             var green = node.GreenNode;
             var idx = index;
             var slotIndex = 0;
@@ -379,7 +380,7 @@ namespace Microsoft.Language.Xml
         /// <summary>Determines whether the specified object is equal to the current instance.</summary>
         /// <returns>true if the specified object is a <see cref="ChildSyntaxList" /> structure and is equal to the current instance; otherwise, false.</returns>
         /// <param name="obj">The object to be compared with the current instance.</param>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ChildSyntaxList && Equals((ChildSyntaxList)obj);
         }
@@ -470,7 +471,7 @@ namespace Microsoft.Language.Xml
                 _childIndex = -1;
             }
 
-            internal bool TryMoveNextAndGetCurrent(out SyntaxNode current)
+            internal bool TryMoveNextAndGetCurrent([NotNullWhen(true)] out SyntaxNode? current)
             {
                 if (!MoveNext())
                 {
@@ -482,7 +483,7 @@ namespace Microsoft.Language.Xml
                 return true;
             }
 
-            internal SyntaxNode TryMoveNextAndGetCurrentAsNode()
+            internal SyntaxNode? TryMoveNextAndGetCurrentAsNode()
             {
                 while (MoveNext())
                 {
@@ -595,7 +596,7 @@ namespace Microsoft.Language.Xml
                 return _node != null ? Hash.Combine(_node.GetHashCode(), _count) : 0;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return (obj is Reversed) && Equals((Reversed)obj);
             }

--- a/src/Microsoft.Language.Xml/Syntax/IXmlElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/IXmlElementSyntax.cs
@@ -4,15 +4,15 @@ namespace Microsoft.Language.Xml
 {
     public interface IXmlElementSyntax
     {
-        string Name { get; }
-        XmlNameSyntax NameNode { get; }
+        string? Name { get; }
+        XmlNameSyntax? NameNode { get; }
         SyntaxList<SyntaxNode> Content { get; }
-        IXmlElementSyntax Parent { get; }
+        IXmlElementSyntax? Parent { get; }
         IEnumerable<IXmlElementSyntax> Elements { get; }
-        IEnumerable<XmlAttributeSyntax> Attributes { get; }
+        IEnumerable<XmlAttributeSyntax>? Attributes { get; }
         SyntaxList<XmlAttributeSyntax> AttributesNode { get; }
-        XmlAttributeSyntax GetAttribute(string localName, string prefix = null);
-        string GetAttributeValue(string localName, string prefix = null);
+        XmlAttributeSyntax? GetAttribute(string localName, string? prefix = null);
+        string? GetAttributeValue(string localName, string? prefix = null);
         IXmlElement AsElement { get; }
         XmlNodeSyntax AsNode { get; }
         string ToFullString();

--- a/src/Microsoft.Language.Xml/Syntax/KeywordSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/KeywordSyntax.cs
@@ -6,29 +6,29 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : SyntaxToken.Green
         {
-            internal Green(string name, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(SyntaxKind.XmlKeyword, name, leadingTrivia, trailingTrivia)
             {
             }
 
-            internal Green(string name, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlKeyword, name, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new KeywordSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new KeywordSyntax(this, parent, position);
 
-            public override SyntaxToken.Green WithLeadingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithLeadingTrivia(GreenNode? trivia)
             {
                 return new Green(Text, trivia, TrailingTrivia);
             }
 
-            public override SyntaxToken.Green WithTrailingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithTrailingTrivia(GreenNode? trivia)
             {
                 return new Green(Text, LeadingTrivia, trivia);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(Text, LeadingTrivia, TrailingTrivia, diagnostics, GetAnnotations());
             }
@@ -43,18 +43,18 @@ namespace Microsoft.Language.Xml
 
         public string Keyword => Text;
 
-        internal KeywordSyntax(Green green, SyntaxNode parent, int position)
+        internal KeywordSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia)
         {
             return (KeywordSyntax)new Green(Text, trivia?.GreenNode, GetTrailingTrivia().Node?.GreenNode).CreateRed(Parent, Start);
         }
 
-        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia)
         {
             return (KeywordSyntax)new Green(Text, GetLeadingTrivia().Node?.GreenNode, trivia?.GreenNode).CreateRed(Parent, Start);
         }

--- a/src/Microsoft.Language.Xml/Syntax/PunctuationSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/PunctuationSyntax.cs
@@ -6,29 +6,29 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : SyntaxToken.Green
         {
-            internal Green(SyntaxKind kind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(SyntaxKind kind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(kind, name, leadingTrivia, trailingTrivia)
             {
             }
 
-            internal Green(SyntaxKind kind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxKind kind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(kind, name, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new PunctuationSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new PunctuationSyntax(this, parent, position);
 
-            public override SyntaxToken.Green WithLeadingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithLeadingTrivia(GreenNode? trivia)
             {
                 return new Green(Kind, Text, trivia, TrailingTrivia);
             }
 
-            public override SyntaxToken.Green WithTrailingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithTrailingTrivia(GreenNode? trivia)
             {
                 return new Green(Kind, Text, LeadingTrivia, trivia);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(Kind, Text, LeadingTrivia, TrailingTrivia, diagnostics, GetAnnotations());
             }
@@ -43,18 +43,18 @@ namespace Microsoft.Language.Xml
 
         public string Punctuation => Text;
 
-        internal PunctuationSyntax(Green green, SyntaxNode parent, int position)
+        internal PunctuationSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia)
         {
             return (PunctuationSyntax)new Green(Kind, Text, trivia?.GreenNode, GetTrailingTrivia().Node?.GreenNode).CreateRed(Parent, Start);
         }
 
-        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia)
         {
             return (PunctuationSyntax)new Green(Kind, Text, GetLeadingTrivia().Node?.GreenNode, trivia?.GreenNode).CreateRed(Parent, Start);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SkippedTokensTriviaSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SkippedTokensTriviaSyntax.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Language.Xml
     {
         internal class Green : GreenNode
         {
-            readonly GreenNode tokens;
+            readonly GreenNode? tokens;
 
-            internal Green(GreenNode tokens)
+            internal Green(GreenNode? tokens)
                 : base(SyntaxKind.SkippedTokensTrivia)
             {
                 this.SlotCount = 1;
@@ -18,7 +18,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(tokens);
             }
 
-            internal Green(GreenNode tokens, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(GreenNode? tokens, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.SkippedTokensTrivia, diagnostics, annotations)
             {
                 this.SlotCount = 1;
@@ -26,9 +26,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(tokens);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new SkippedTokensTriviaSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new SkippedTokensTriviaSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -42,7 +42,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitSkippedTokensTrivia(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(tokens, diagnostics, GetAnnotations());
             }
@@ -55,11 +55,11 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        SyntaxNode textTokens;
+        SyntaxNode? textTokens;
 
         public SyntaxList<SyntaxToken> Tokens => new SyntaxList<SyntaxToken>(GetRed(ref textTokens, 0));
 
-        internal SkippedTokensTriviaSyntax(Green green, SyntaxNode parent, int position)
+        internal SkippedTokensTriviaSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -72,7 +72,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitSkippedTokensTrivia(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -81,7 +81,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/SkippedTriviaBuilder.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SkippedTriviaBuilder.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Language.Xml
         private InternalSyntax.SyntaxListBuilder<GreenNode> skippedTokensBuilder = InternalSyntax.SyntaxListBuilder<GreenNode>.Create();
         private bool preserveExistingDiagnostics;
         private bool addDiagnosticsToFirstTokenOnly;
-        private IEnumerable<DiagnosticInfo> diagnosticsToAdd;
+        private IEnumerable<DiagnosticInfo>? diagnosticsToAdd;
 
         // Add a trivia to the triva we are accumulating.
-        private void AddTrivia(GreenNode trivia)
+        private void AddTrivia(GreenNode? trivia)
         {
             FinishInProgressTokens();
             triviaListBuilder.AddRange(trivia);
@@ -72,7 +72,7 @@ namespace Microsoft.Language.Xml
             ////    token = token.WithoutDiagnostics();
             ////}
 
-            GreenNode trailingTrivia = null;
+            GreenNode? trailingTrivia = null;
             if (token.HasTrailingTrivia && (isLast || isMissing || token.GetTrailingTrivia().TriviaListContainsStructuredTrivia()))
             {
                 trailingTrivia = token.GetTrailingTrivia();

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxAnnotation.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxAnnotation.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Language.Xml
         private static long s_nextId;
 
         // use a value identity instead of object identity so a deserialized instance matches the original instance.
-        public string Kind { get; }
-        public string Data { get; }
+        public string? Kind { get; }
+        public string? Data { get; }
 
         public SyntaxAnnotation()
         {
@@ -42,19 +42,19 @@ namespace Microsoft.Language.Xml
             return string.Format("Annotation: Kind='{0}' Data='{1}'", this.Kind ?? "", this.Data ?? "");
         }
 
-        public bool Equals(SyntaxAnnotation other)
+        public bool Equals(SyntaxAnnotation? other)
         {
-            return (object)other != null && _id == other._id;
+            return (object?)other != null && _id == other._id;
         }
 
-        public static bool operator ==(SyntaxAnnotation left, SyntaxAnnotation right)
+        public static bool operator ==(SyntaxAnnotation? left, SyntaxAnnotation? right)
         {
-            if ((object)left == (object)right)
+            if ((object?)left == (object?)right)
             {
                 return true;
             }
 
-            if ((object)left == null || (object)right == null)
+            if ((object?)left == null || (object?)right == null)
             {
                 return false;
             }
@@ -62,14 +62,14 @@ namespace Microsoft.Language.Xml
             return left.Equals(right);
         }
 
-        public static bool operator !=(SyntaxAnnotation left, SyntaxAnnotation right)
+        public static bool operator !=(SyntaxAnnotation? left, SyntaxAnnotation? right)
         {
-            if ((object)left == (object)right)
+            if ((object?)left == (object?)right)
             {
                 return false;
             }
 
-            if ((object)left == null || (object)right == null)
+            if ((object?)left == null || (object?)right == null)
             {
                 return true;
             }
@@ -77,7 +77,7 @@ namespace Microsoft.Language.Xml
             return !left.Equals(right);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return this.Equals(obj as SyntaxAnnotation);
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxDiffer.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxDiffer.cs
@@ -4,6 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
+#pragma warning disable CS8602
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     internal class SyntaxDiffer
@@ -461,10 +464,10 @@ namespace Microsoft.Language.Xml
         private readonly struct ChangeRecord
         {
             public readonly TextChangeRange Range;
-            public readonly Queue<SyntaxNode> OldNodes;
-            public readonly Queue<SyntaxNode> NewNodes;
+            public readonly Queue<SyntaxNode>? OldNodes;
+            public readonly Queue<SyntaxNode>? NewNodes;
 
-            internal ChangeRecord(TextChangeRange range, Queue<SyntaxNode> oldNodes, Queue<SyntaxNode> newNodes)
+            internal ChangeRecord(TextChangeRange range, Queue<SyntaxNode>? oldNodes, Queue<SyntaxNode>? newNodes)
             {
                 this.Range = range;
                 this.OldNodes = oldNodes;
@@ -616,7 +619,7 @@ namespace Microsoft.Language.Xml
             return TextSpan.FromBounds(start, end);
         }
 
-        private static Queue<SyntaxNode> Combine(Queue<SyntaxNode> first, Queue<SyntaxNode> next)
+        private static Queue<SyntaxNode>? Combine(Queue<SyntaxNode>? first, Queue<SyntaxNode>? next)
         {
             if (first == null || first.Count == 0)
             {
@@ -636,7 +639,7 @@ namespace Microsoft.Language.Xml
             return first;
         }
 
-        private static Queue<SyntaxNode> CopyFirst(Stack<SyntaxNode> stack, int n)
+        private static Queue<SyntaxNode>? CopyFirst(Stack<SyntaxNode> stack, int n)
         {
             if (n == 0)
             {
@@ -688,9 +691,9 @@ namespace Microsoft.Language.Xml
         private readonly struct ChangeRangeWithText
         {
             public readonly TextChangeRange Range;
-            public readonly string NewText;
+            public readonly string? NewText;
 
-            public ChangeRangeWithText(TextChangeRange range, string newText)
+            public ChangeRangeWithText(TextChangeRange range, string? newText)
             {
                 this.Range = range;
                 this.NewText = newText;
@@ -793,7 +796,7 @@ namespace Microsoft.Language.Xml
             return builder.ToString();
         }
 
-        private static void CopyText(Queue<SyntaxNode> queue, StringBuilder builder)
+        private static void CopyText(Queue<SyntaxNode>? queue, StringBuilder builder)
         {
             builder.Length = 0;
 

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxFactory.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxFactory.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Language.Xml
         public static readonly SyntaxTrivia CarriageReturnLineFeed = EndOfLineTrivia("\r\n");
 
         public static XmlDocumentSyntax XmlDocument(
-            XmlDeclarationSyntax prologue,
+            XmlDeclarationSyntax? prologue,
             SyntaxList<SyntaxNode> precedingMisc,
-            XmlNodeSyntax body,
+            XmlNodeSyntax? body,
             SyntaxList<XmlNodeSyntax> followingMisc,
             SkippedTokensTriviaSyntax skippedTokens,
             SyntaxToken eof)
@@ -21,12 +21,12 @@ namespace Microsoft.Language.Xml
         }
 
         public static XmlDocumentSyntax XmlDocument(
-            XmlDeclarationSyntax prologue,
-            SyntaxNode precedingMisc,
-            XmlNodeSyntax body,
-            SyntaxNode followingMisc,
-            SkippedTokensTriviaSyntax skippedTokens,
-            SyntaxToken eof)
+            XmlDeclarationSyntax? prologue,
+            SyntaxNode? precedingMisc,
+            XmlNodeSyntax? body,
+            SyntaxNode? followingMisc,
+            SkippedTokensTriviaSyntax? skippedTokens,
+            SyntaxToken? eof)
         {
             return (XmlDocumentSyntax)new XmlDocumentSyntax.Green(prologue?.GreenNode,
                                                                   precedingMisc?.GreenNode,
@@ -36,7 +36,7 @@ namespace Microsoft.Language.Xml
                                                                   eof?.GreenNode).CreateRed();
         }
 
-        public static XmlNameSyntax XmlName(XmlPrefixSyntax prefix, XmlNameTokenSyntax localName)
+        public static XmlNameSyntax XmlName(XmlPrefixSyntax? prefix, XmlNameTokenSyntax? localName)
         {
             return (XmlNameSyntax)new XmlNameSyntax.Green(prefix?.GreenNode, localName?.GreenNode).CreateRed();
         }
@@ -46,12 +46,12 @@ namespace Microsoft.Language.Xml
             return Punctuation(kind, spelling, precedingTrivia.Node, followingTrivia.Node);
         }
 
-        public static PunctuationSyntax Punctuation(SyntaxKind kind, string spelling, SyntaxNode precedingTrivia, SyntaxNode followingTrivia)
+        public static PunctuationSyntax Punctuation(SyntaxKind kind, string spelling, SyntaxNode? precedingTrivia, SyntaxNode? followingTrivia)
         {
             return (PunctuationSyntax)new PunctuationSyntax.Green(kind, spelling, precedingTrivia?.GreenNode, followingTrivia?.GreenNode).CreateRed();
         }
 
-        public static PunctuationSyntax MissingPunctuation(SyntaxKind kind, SyntaxNode leadingTrivia = null)
+        public static PunctuationSyntax MissingPunctuation(SyntaxKind kind, SyntaxNode? leadingTrivia = null)
         {
             return (PunctuationSyntax)new PunctuationSyntax.Green(kind, string.Empty, leadingTrivia?.GreenNode, null).CreateRed();
         }
@@ -95,17 +95,17 @@ namespace Microsoft.Language.Xml
             return SkippedTokensTrivia(syntaxList.Node);
         }
 
-        public static SyntaxNode SkippedTokensTrivia(SyntaxNode syntaxList)
+        public static SyntaxNode SkippedTokensTrivia(SyntaxNode? syntaxList)
         {
             return (SkippedTokensTriviaSyntax)new SkippedTokensTriviaSyntax.Green(syntaxList?.GreenNode).CreateRed();
         }
 
-        public static XmlElementSyntax XmlElement(XmlElementStartTagSyntax startElement, SyntaxList<SyntaxNode> contentList, XmlElementEndTagSyntax endElement)
+        public static XmlElementSyntax XmlElement(XmlElementStartTagSyntax? startElement, SyntaxList<SyntaxNode> contentList, XmlElementEndTagSyntax? endElement)
         {
             return XmlElement(startElement, contentList.Node, endElement);
         }
 
-        public static XmlElementSyntax XmlElement(XmlElementStartTagSyntax startElement, SyntaxNode content, XmlElementEndTagSyntax endElement)
+        public static XmlElementSyntax XmlElement(XmlElementStartTagSyntax? startElement, SyntaxNode? content, XmlElementEndTagSyntax? endElement)
         {
             return (XmlElementSyntax)new XmlElementSyntax.Green(startElement?.GreenNode, content?.GreenNode, endElement?.GreenNode).CreateRed();
         }
@@ -154,12 +154,12 @@ namespace Microsoft.Language.Xml
             return XmlText(textTokens.Node);
         }
 
-        public static XmlTextSyntax XmlText(SyntaxNode textTokens)
+        public static XmlTextSyntax XmlText(SyntaxNode? textTokens)
         {
             return (XmlTextSyntax)new XmlTextSyntax.Green(textTokens?.GreenNode).CreateRed();
         }
 
-        public static SyntaxToken Token(SyntaxNode leadingTrivia, SyntaxKind kind, SyntaxNode trailingTrivia, string text)
+        public static SyntaxToken Token(SyntaxNode? leadingTrivia, SyntaxKind kind, SyntaxNode? trailingTrivia, string text)
         {
             return (PunctuationSyntax)new PunctuationSyntax.Green(kind, text, leadingTrivia?.GreenNode, trailingTrivia?.GreenNode).CreateRed();
         }
@@ -169,12 +169,12 @@ namespace Microsoft.Language.Xml
             return BadToken(subkind, spelling, precedingTrivia.Node, followingTrivia.Node);
         }
 
-        public static BadTokenSyntax BadToken(SyntaxSubKind subkind, string spelling, SyntaxNode precedingTrivia, SyntaxNode followingTrivia)
+        public static BadTokenSyntax BadToken(SyntaxSubKind subkind, string spelling, SyntaxNode? precedingTrivia, SyntaxNode? followingTrivia)
         {
             return (BadTokenSyntax)new BadTokenSyntax.Green(subkind, spelling, precedingTrivia?.GreenNode, followingTrivia?.GreenNode).CreateRed();
         }
 
-        public static XmlNameTokenSyntax XmlNameToken(string text, SyntaxNode precedingTrivia, SyntaxNode followingTrivia)
+        public static XmlNameTokenSyntax XmlNameToken(string text, SyntaxNode? precedingTrivia, SyntaxNode? followingTrivia)
         {
             return (XmlNameTokenSyntax)new XmlNameTokenSyntax.Green(text, precedingTrivia?.GreenNode, followingTrivia?.GreenNode).CreateRed();
         }
@@ -209,12 +209,12 @@ namespace Microsoft.Language.Xml
         ''' </summary>
         */
 
-        public static XmlStringSyntax XmlString(PunctuationSyntax startQuoteToken, SyntaxList<XmlTextTokenSyntax> textTokens, PunctuationSyntax endQuoteToken)
+        public static XmlStringSyntax XmlString(PunctuationSyntax? startQuoteToken, SyntaxList<XmlTextTokenSyntax> textTokens, PunctuationSyntax? endQuoteToken)
         {
             return XmlString(startQuoteToken, textTokens.Node, endQuoteToken);
         }
 
-        public static XmlStringSyntax XmlString(PunctuationSyntax startQuoteToken, SyntaxNode textTokens, PunctuationSyntax endQuoteToken)
+        public static XmlStringSyntax XmlString(PunctuationSyntax? startQuoteToken, SyntaxNode? textTokens, PunctuationSyntax? endQuoteToken)
         {
             //Debug.Assert(startQuoteToken != null && SyntaxFacts.IsXmlStringStartQuoteToken(startQuoteToken.Kind));
             //Debug.Assert(endQuoteToken != null && SyntaxFacts.IsXmlStringEndQuoteToken(endQuoteToken.Kind));
@@ -249,12 +249,12 @@ namespace Microsoft.Language.Xml
             return (XmlDeclarationSyntax)new XmlDeclarationSyntax.Green(lessThanQuestionToken?.GreenNode, xmlKeyword?.GreenNode, version?.GreenNode, encoding?.GreenNode, standalone?.GreenNode, questionGreaterThanToken.GreenNode).CreateRed();
         }
 
-        public static XmlAttributeSyntax XmlAttribute(XmlNameSyntax name, PunctuationSyntax equals, XmlNodeSyntax value)
+        public static XmlAttributeSyntax XmlAttribute(XmlNameSyntax? name, PunctuationSyntax? equals, XmlNodeSyntax? value)
         {
             return (XmlAttributeSyntax)new XmlAttributeSyntax.Green(name?.GreenNode, equals?.GreenNode, value?.GreenNode).CreateRed();
         }
 
-        public static XmlPrefixSyntax XmlPrefix(XmlNameTokenSyntax localName, PunctuationSyntax colon)
+        public static XmlPrefixSyntax XmlPrefix(XmlNameTokenSyntax? localName, PunctuationSyntax? colon)
         {
             return (XmlPrefixSyntax)new XmlPrefixSyntax.Green(localName?.GreenNode, colon?.GreenNode).CreateRed();
         }
@@ -269,10 +269,10 @@ namespace Microsoft.Language.Xml
         }
 
         public static XmlProcessingInstructionSyntax XmlProcessingInstruction(
-            PunctuationSyntax beginProcessingInstruction,
-            XmlNameTokenSyntax name,
-            SyntaxNode toList,
-            PunctuationSyntax endProcessingInstruction)
+            PunctuationSyntax? beginProcessingInstruction,
+            XmlNameTokenSyntax? name,
+            SyntaxNode? toList,
+            PunctuationSyntax? endProcessingInstruction)
         {
             return (XmlProcessingInstructionSyntax)new XmlProcessingInstructionSyntax.Green(beginProcessingInstruction?.GreenNode, name?.GreenNode, toList?.GreenNode, endProcessingInstruction?.GreenNode).CreateRed();
         }
@@ -282,7 +282,7 @@ namespace Microsoft.Language.Xml
             return XmlTextLiteralToken(text, leadingTrivia.Node, trailingTrivia.Node);
         }
 
-        public static XmlTextTokenSyntax XmlTextLiteralToken(string text, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
+        public static XmlTextTokenSyntax XmlTextLiteralToken(string text, SyntaxNode? leadingTrivia, SyntaxNode? trailingTrivia)
         {
             return (XmlTextTokenSyntax)new XmlTextTokenSyntax.Green(text, leadingTrivia?.GreenNode, trailingTrivia?.GreenNode).CreateRed();
         }
@@ -296,7 +296,7 @@ namespace Microsoft.Language.Xml
           ''' The actual text of this token.
           ''' </param>
         */
-        public static XmlEntityTokenSyntax XmlEntityLiteralToken(string text, string value, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
+        public static XmlEntityTokenSyntax XmlEntityLiteralToken(string text, string value, SyntaxNode? leadingTrivia, SyntaxNode? trailingTrivia)
         {
             Debug.Assert(value != null);
             return (XmlEntityTokenSyntax)new XmlEntityTokenSyntax.Green(text, value, leadingTrivia?.GreenNode, trailingTrivia?.GreenNode).CreateRed();
@@ -322,9 +322,9 @@ namespace Microsoft.Language.Xml
         }
 
         public static XmlCDataSectionSyntax XmlCDataSection(
-            PunctuationSyntax beginCData,
-            SyntaxNode result,
-            PunctuationSyntax endCData)
+            PunctuationSyntax? beginCData,
+            SyntaxNode? result,
+            PunctuationSyntax? endCData)
         {
             return (XmlCDataSectionSyntax)new XmlCDataSectionSyntax.Green(beginCData?.GreenNode, result?.GreenNode, endCData?.GreenNode).CreateRed();
         }
@@ -338,9 +338,9 @@ namespace Microsoft.Language.Xml
         }
 
         public static XmlNodeSyntax XmlComment(
-            PunctuationSyntax beginComment,
-            SyntaxNode result,
-            PunctuationSyntax endComment)
+            PunctuationSyntax? beginComment,
+            SyntaxNode? result,
+            PunctuationSyntax? endComment)
         {
             return (XmlCommentSyntax)new XmlCommentSyntax.Green(beginComment?.GreenNode, result?.GreenNode, endComment?.GreenNode).CreateRed();
         }
@@ -350,7 +350,7 @@ namespace Microsoft.Language.Xml
             return Keyword(name, leadingTrivia.Node, trailingTrivia.Node);
         }
 
-        public static KeywordSyntax Keyword(string name, SyntaxNode leadingTrivia, SyntaxNode trailingTrivia)
+        public static KeywordSyntax Keyword(string name, SyntaxNode? leadingTrivia, SyntaxNode? trailingTrivia)
         {
             return (KeywordSyntax)new KeywordSyntax.Green(name, leadingTrivia?.GreenNode, trailingTrivia?.GreenNode).CreateRed();
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxList.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxList.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#pragma warning disable CS8601
+
 namespace Microsoft.Language.Xml
 {
     public abstract class SyntaxList : SyntaxNode
     {
-        internal SyntaxList(InternalSyntax.SyntaxList green, SyntaxNode parent, int position)
+        internal SyntaxList(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
         }
@@ -16,22 +18,22 @@ namespace Microsoft.Language.Xml
             return visitor.Visit(this);
         }
 
-        protected internal override SyntaxNode ReplaceCore<TNode>(IEnumerable<TNode> nodes = null, Func<TNode, TNode, SyntaxNode> computeReplacementNode = null, IEnumerable<SyntaxToken> tokens = null, Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken = null, IEnumerable<SyntaxTrivia> trivia = null, Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
+        protected internal override SyntaxNode ReplaceCore<TNode>(IEnumerable<TNode>? nodes = null, Func<TNode, TNode, SyntaxNode>? computeReplacementNode = null, IEnumerable<SyntaxToken>? tokens = null, Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken = null, IEnumerable<SyntaxTrivia>? trivia = null, Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia = null)
         {
             throw new InvalidOperationException();
         }
 
         internal class WithTwoChildren : SyntaxList
         {
-            private SyntaxNode _child0;
-            private SyntaxNode _child1;
+            private SyntaxNode? _child0;
+            private SyntaxNode? _child1;
 
-            internal WithTwoChildren(InternalSyntax.SyntaxList green, SyntaxNode parent, int position)
+            internal WithTwoChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
                 : base(green, parent, position)
             {
             }
 
-            internal override SyntaxNode GetNodeSlot(int index)
+            internal override SyntaxNode? GetNodeSlot(int index)
             {
                 switch (index)
                 {
@@ -44,7 +46,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            internal override SyntaxNode GetCachedSlot(int index)
+            internal override SyntaxNode? GetCachedSlot(int index)
             {
                 switch (index)
                 {
@@ -60,16 +62,16 @@ namespace Microsoft.Language.Xml
 
         internal class WithThreeChildren : SyntaxList
         {
-            private SyntaxNode _child0;
-            private SyntaxNode _child1;
-            private SyntaxNode _child2;
+            private SyntaxNode? _child0;
+            private SyntaxNode? _child1;
+            private SyntaxNode? _child2;
 
-            internal WithThreeChildren(InternalSyntax.SyntaxList green, SyntaxNode parent, int position)
+            internal WithThreeChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
                 : base(green, parent, position)
             {
             }
 
-            internal override SyntaxNode GetNodeSlot(int index)
+            internal override SyntaxNode? GetNodeSlot(int index)
             {
                 switch (index)
                 {
@@ -84,7 +86,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            internal override SyntaxNode GetCachedSlot(int index)
+            internal override SyntaxNode? GetCachedSlot(int index)
             {
                 switch (index)
                 {
@@ -104,7 +106,7 @@ namespace Microsoft.Language.Xml
         {
             private readonly ArrayElement<SyntaxNode>[] _children;
 
-            internal WithManyChildren(InternalSyntax.SyntaxList green, SyntaxNode parent, int position)
+            internal WithManyChildren(InternalSyntax.SyntaxList green, SyntaxNode? parent, int position)
                 : base(green, parent, position)
             {
                 _children = new ArrayElement<SyntaxNode>[green.SlotCount];
@@ -115,7 +117,7 @@ namespace Microsoft.Language.Xml
                 return this.GetRedElement(ref _children[index].Value, index);
             }
 
-            internal override SyntaxNode GetCachedSlot(int index)
+            internal override SyntaxNode? GetCachedSlot(int index)
             {
                 return _children[index];
             }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxListBuilder.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxListBuilder.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
@@ -131,7 +133,7 @@ namespace Microsoft.Language.Xml
             return false;
         }
 
-        internal GreenNode ToListNode()
+        internal GreenNode? ToListNode()
         {
             switch (this.Count)
             {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxListBuilderExtensions.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxListBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     internal static class SyntaxListBuilderExtensions

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxList`1.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxList`1.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
+#pragma warning disable CS8600
+#pragma warning disable CS8602
+#pragma warning disable CS8603
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
@@ -12,9 +16,9 @@ namespace Microsoft.Language.Xml
     public readonly struct SyntaxList<TNode> : IReadOnlyList<TNode>, IEquatable<SyntaxList<TNode>>
         where TNode : SyntaxNode
     {
-        private readonly SyntaxNode _node;
+        private readonly SyntaxNode? _node;
 
-        internal SyntaxList(SyntaxNode node)
+        internal SyntaxList(SyntaxNode? node)
         {
             _node = node;
         }
@@ -37,7 +41,7 @@ namespace Microsoft.Language.Xml
         {
         }
 
-        private static SyntaxNode CreateNode(IEnumerable<TNode> nodes)
+        private static SyntaxNode? CreateNode(IEnumerable<TNode> nodes)
         {
             if (nodes == null)
             {
@@ -55,7 +59,7 @@ namespace Microsoft.Language.Xml
             return builder.ToList().Node;
         }
 
-        internal SyntaxNode Node
+        internal SyntaxNode? Node
         {
             get
             {
@@ -428,7 +432,7 @@ namespace Microsoft.Language.Xml
             return _node == other._node;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SyntaxList<TNode> && Equals((SyntaxList<TNode>)obj);
         }
@@ -561,7 +565,7 @@ namespace Microsoft.Language.Xml
                 _index = -1;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 throw new NotSupportedException();
             }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxNode.Enumerators.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxNode.Enumerators.cs
@@ -2,27 +2,31 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
+#pragma warning disable CS8601
+#pragma warning disable CS8602
 
 namespace Microsoft.Language.Xml
 {
     public abstract partial class SyntaxNode
     {
-        private IEnumerable<SyntaxNode> DescendantNodesImpl(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren, bool descendIntoTrivia, bool includeSelf)
+        private IEnumerable<SyntaxNode> DescendantNodesImpl(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren, bool descendIntoTrivia, bool includeSelf)
         {
             return descendIntoTrivia
                 ? DescendantNodesAndTokensImpl(span, descendIntoChildren, true, includeSelf).Where(e => e.IsNode)
                 : DescendantNodesOnly(span, descendIntoChildren, includeSelf);
         }
 
-        private IEnumerable<SyntaxNode> DescendantNodesAndTokensImpl(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren, bool descendIntoTrivia, bool includeSelf)
+        private IEnumerable<SyntaxNode> DescendantNodesAndTokensImpl(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren, bool descendIntoTrivia, bool includeSelf)
         {
             return descendIntoTrivia
                 ? DescendantNodesAndTokensIntoTrivia(span, descendIntoChildren, includeSelf)
                 : DescendantNodesAndTokensOnly(span, descendIntoChildren, includeSelf);
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaImpl(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaImpl(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return descendIntoTrivia
                 ? DescendantTriviaIntoTrivia(span, descendIntoChildren)
@@ -40,10 +44,10 @@ namespace Microsoft.Language.Xml
         {
             private static readonly ObjectPool<ChildSyntaxList.Enumerator[]> s_stackPool = new ObjectPool<ChildSyntaxList.Enumerator[]>(() => new ChildSyntaxList.Enumerator[16]);
 
-            private ChildSyntaxList.Enumerator[] _stack;
+            private ChildSyntaxList.Enumerator[]? _stack;
             private int _stackPtr;
 
-            public ChildSyntaxListEnumeratorStack(SyntaxNode startingNode, Func<SyntaxNode, bool> descendIntoChildren)
+            public ChildSyntaxListEnumeratorStack(SyntaxNode startingNode, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 if (descendIntoChildren == null || descendIntoChildren(startingNode))
                 {
@@ -60,7 +64,7 @@ namespace Microsoft.Language.Xml
 
             public bool IsNotEmpty { get { return _stackPtr >= 0; } }
 
-            public bool TryGetNextInSpan(in TextSpan span, out SyntaxNode value)
+            public bool TryGetNextInSpan(in TextSpan span, [NotNullWhen(true)] out SyntaxNode? value)
             {
                 while (_stack[_stackPtr].TryMoveNextAndGetCurrent(out value))
                 {
@@ -74,9 +78,9 @@ namespace Microsoft.Language.Xml
                 return false;
             }
 
-            public SyntaxNode TryGetNextAsNodeInSpan(in TextSpan span)
+            public SyntaxNode? TryGetNextAsNodeInSpan(in TextSpan span)
             {
-                SyntaxNode nodeValue;
+                SyntaxNode? nodeValue;
                 while ((nodeValue = _stack[_stackPtr].TryMoveNextAndGetCurrentAsNode()) != null)
                 {
                     if (IsInSpan(in span, nodeValue.FullSpan))
@@ -100,7 +104,7 @@ namespace Microsoft.Language.Xml
                 _stack[_stackPtr].InitializeFrom(node);
             }
 
-            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool> descendIntoChildren)
+            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 if (descendIntoChildren == null || descendIntoChildren(node))
                 {
@@ -185,9 +189,9 @@ namespace Microsoft.Language.Xml
 
             private ChildSyntaxListEnumeratorStack _nodeStack;
             private TriviaListEnumeratorStack _triviaStack;
-            private readonly ArrayBuilder<Which> _discriminatorStack;
+            private readonly ArrayBuilder<Which>? _discriminatorStack;
 
-            public TwoEnumeratorListStack(SyntaxNode startingNode, Func<SyntaxNode, bool> descendIntoChildren)
+            public TwoEnumeratorListStack(SyntaxNode startingNode, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 _nodeStack = new ChildSyntaxListEnumeratorStack(startingNode, descendIntoChildren);
                 _triviaStack = new TriviaListEnumeratorStack();
@@ -209,7 +213,7 @@ namespace Microsoft.Language.Xml
                 return _discriminatorStack[_discriminatorStack.Count - 1];
             }
 
-            public bool TryGetNextInSpan(in TextSpan span, out SyntaxNode value)
+            public bool TryGetNextInSpan(in TextSpan span, [NotNullWhen(true)] out SyntaxNode? value)
             {
                 if (_nodeStack.TryGetNextInSpan(in span, out value))
                 {
@@ -231,7 +235,7 @@ namespace Microsoft.Language.Xml
                 return false;
             }
 
-            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool> descendIntoChildren)
+            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 if (descendIntoChildren == null || descendIntoChildren(node))
                 {
@@ -271,10 +275,10 @@ namespace Microsoft.Language.Xml
 
             private ChildSyntaxListEnumeratorStack _nodeStack;
             private TriviaListEnumeratorStack _triviaStack;
-            private readonly ArrayBuilder<SyntaxNode> _tokenStack;
-            private readonly ArrayBuilder<Which> _discriminatorStack;
+            private readonly ArrayBuilder<SyntaxNode>? _tokenStack;
+            private readonly ArrayBuilder<Which>? _discriminatorStack;
 
-            public ThreeEnumeratorListStack(SyntaxNode startingNode, Func<SyntaxNode, bool> descendIntoChildren)
+            public ThreeEnumeratorListStack(SyntaxNode startingNode, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 _nodeStack = new ChildSyntaxListEnumeratorStack(startingNode, descendIntoChildren);
                 _triviaStack = new TriviaListEnumeratorStack();
@@ -299,7 +303,7 @@ namespace Microsoft.Language.Xml
                 return _discriminatorStack[_discriminatorStack.Count - 1];
             }
 
-            public bool TryGetNextInSpan(in TextSpan span, out SyntaxNode value)
+            public bool TryGetNextInSpan(in TextSpan span, [NotNullWhen(true)] out SyntaxNode? value)
             {
                 if (_nodeStack.TryGetNextInSpan(in span, out value))
                 {
@@ -329,7 +333,7 @@ namespace Microsoft.Language.Xml
                 return result;
             }
 
-            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool> descendIntoChildren)
+            public void PushChildren(SyntaxNode node, Func<SyntaxNode, bool>? descendIntoChildren)
             {
                 if (descendIntoChildren == null || descendIntoChildren(node))
                 {
@@ -365,7 +369,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private IEnumerable<SyntaxNode> DescendantNodesOnly(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren, bool includeSelf)
+        private IEnumerable<SyntaxNode> DescendantNodesOnly(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren, bool includeSelf)
         {
             if (includeSelf && IsInSpan(in span, this.FullSpan))
             {
@@ -376,7 +380,7 @@ namespace Microsoft.Language.Xml
             {
                 while (stack.IsNotEmpty)
                 {
-                    SyntaxNode nodeValue = stack.TryGetNextAsNodeInSpan(in span);
+                    SyntaxNode? nodeValue = stack.TryGetNextAsNodeInSpan(in span);
                     if (nodeValue != null)
                     {
                         // PERF: Push before yield return so that "nodeValue" is 'dead' after the yield
@@ -390,7 +394,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private IEnumerable<SyntaxNode> DescendantNodesAndTokensOnly(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren, bool includeSelf)
+        private IEnumerable<SyntaxNode> DescendantNodesAndTokensOnly(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren, bool includeSelf)
         {
             if (includeSelf && IsInSpan(in span, this.FullSpan))
             {
@@ -401,7 +405,7 @@ namespace Microsoft.Language.Xml
             {
                 while (stack.IsNotEmpty)
                 {
-                    SyntaxNode value;
+                    SyntaxNode? value;
                     if (stack.TryGetNextInSpan(in span, out value))
                     {
                         // PERF: Push before yield return so that "value" is 'dead' after the yield
@@ -419,7 +423,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private IEnumerable<SyntaxNode> DescendantNodesAndTokensIntoTrivia(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren, bool includeSelf)
+        private IEnumerable<SyntaxNode> DescendantNodesAndTokensIntoTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren, bool includeSelf)
         {
             if (includeSelf && IsInSpan(in span, this.FullSpan))
             {
@@ -433,7 +437,7 @@ namespace Microsoft.Language.Xml
                     switch (stack.PeekNext())
                     {
                         case ThreeEnumeratorListStack.Which.Node:
-                            SyntaxNode value;
+                            SyntaxNode? value;
                             if (stack.TryGetNextInSpan(in span, out value))
                             {
                                 // PERF: The following code has an unusual structure (note the 'break' out of
@@ -482,13 +486,13 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaOnly(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaOnly(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren)
         {
             using (var stack = new ChildSyntaxListEnumeratorStack(this, descendIntoChildren))
             {
                 while (stack.IsNotEmpty)
                 {
-                    SyntaxNode value;
+                    SyntaxNode? value;
                     if (stack.TryGetNextInSpan(in span, out value))
                     {
                         if (value.IsNode)
@@ -522,7 +526,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private IEnumerable<SyntaxTrivia> DescendantTriviaIntoTrivia(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren)
+        private IEnumerable<SyntaxTrivia> DescendantTriviaIntoTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren)
         {
             using (var stack = new TwoEnumeratorListStack(this, descendIntoChildren))
             {
@@ -531,7 +535,7 @@ namespace Microsoft.Language.Xml
                     switch (stack.PeekNext())
                     {
                         case TwoEnumeratorListStack.Which.Node:
-                            SyntaxNode value;
+                            SyntaxNode? value;
                             if (stack.TryGetNextInSpan(in span, out value))
                             {
                                 if (value.IsNode)

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxNode.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxNode.cs
@@ -6,13 +6,16 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
+    using System.Diagnostics.CodeAnalysis;
     using InternalSyntax;
 
     public abstract partial class SyntaxNode
     {
-        public SyntaxNode Parent { get; }
+        public SyntaxNode? Parent { get; }
         public int Start { get; }
 
         public SyntaxKind Kind => GreenNode.Kind;
@@ -25,7 +28,7 @@ namespace Microsoft.Language.Xml
 
         internal GreenNode GreenNode { get; }
 
-        internal SyntaxNode(GreenNode green, SyntaxNode parent, int position)
+        internal SyntaxNode(GreenNode green, SyntaxNode? parent, int position)
         {
             this.GreenNode = green;
             this.Parent = parent;
@@ -60,7 +63,7 @@ namespace Microsoft.Language.Xml
             return GreenNode.SlotCount;
         }
 
-        public virtual SyntaxNode GetSlotIncludingTrivia(int index)
+        public virtual SyntaxNode? GetSlotIncludingTrivia(int index)
         {
             return GetNodeSlot(index);
         }
@@ -72,7 +75,7 @@ namespace Microsoft.Language.Xml
             return 0;
         }
 
-        internal SyntaxNode GetRed(ref SyntaxNode field, int slot)
+        internal SyntaxNode? GetRed(ref SyntaxNode? field, int slot)
         {
             var result = field;
 
@@ -89,7 +92,7 @@ namespace Microsoft.Language.Xml
             return result;
         }
 
-        protected T GetRed<T>(ref T field, int slot) where T : SyntaxNode
+        protected T? GetRed<T>(ref T? field, int slot) where T : SyntaxNode
         {
             var result = field;
 
@@ -106,7 +109,8 @@ namespace Microsoft.Language.Xml
             return result;
         }
 
-        internal SyntaxNode GetRedElement(ref SyntaxNode element, int slot)
+        [return: NotNullIfNotNull(nameof(element))]
+        internal SyntaxNode? GetRedElement(ref SyntaxNode? element, int slot)
         {
             Debug.Assert(this.IsList);
 
@@ -149,18 +153,18 @@ namespace Microsoft.Language.Xml
         /// Gets a node at given node index without forcing its creation.
         /// If node was not created it would return null.
         /// </summary>
-        internal abstract SyntaxNode GetCachedSlot(int index);
+        internal abstract SyntaxNode? GetCachedSlot(int index);
 
         /// <summary>
         /// Creates a new tree of nodes with the specified nodes, tokens or trivia replaced.
         /// </summary>
         protected internal virtual SyntaxNode ReplaceCore<TNode>(
-            IEnumerable<TNode> nodes = null,
-            Func<TNode, TNode, SyntaxNode> computeReplacementNode = null,
-            IEnumerable<SyntaxToken> tokens = null,
-            Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken = null,
-            IEnumerable<SyntaxTrivia> trivia = null,
-            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null) where TNode : SyntaxNode
+            IEnumerable<TNode>? nodes = null,
+            Func<TNode, TNode, SyntaxNode>? computeReplacementNode = null,
+            IEnumerable<SyntaxToken>? tokens = null,
+            Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken = null,
+            IEnumerable<SyntaxTrivia>? trivia = null,
+            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia = null) where TNode : SyntaxNode
         {
             return SyntaxReplacer.Replace(this, nodes, computeReplacementNode, tokens, computeReplacementToken, trivia, computeReplacementTrivia);
         }
@@ -217,7 +221,7 @@ namespace Microsoft.Language.Xml
         /// <summary>
         /// Get a list of all the trivia associated with the descendant nodes and tokens.
         /// </summary>
-        public IEnumerable<SyntaxTrivia> DescendantTrivia(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxTrivia> DescendantTrivia(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantTriviaImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia);
         }
@@ -225,7 +229,7 @@ namespace Microsoft.Language.Xml
         /// <summary>
         /// Get a list of all the trivia associated with the descendant nodes and tokens.
         /// </summary>
-        public IEnumerable<SyntaxTrivia> DescendantTrivia(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxTrivia> DescendantTrivia(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantTriviaImpl(span, descendIntoChildren, descendIntoTrivia);
         }
@@ -244,7 +248,7 @@ namespace Microsoft.Language.Xml
             return new ChildSyntaxList(this);
         }
 
-        internal abstract SyntaxNode GetNodeSlot(int index);
+        internal abstract SyntaxNode? GetNodeSlot(int index);
 
         public IEnumerable<SyntaxNode> ChildNodes
         {
@@ -261,7 +265,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public SyntaxNode GetParent(int parentChainLength = 1)
+        public SyntaxNode? GetParent(int parentChainLength = 1)
         {
             var current = this;
             for (int i = 0; i < parentChainLength; i++)
@@ -277,7 +281,7 @@ namespace Microsoft.Language.Xml
             return current;
         }
 
-        public IXmlElementSyntax ParentElement
+        public IXmlElementSyntax? ParentElement
         {
             get
             {
@@ -307,11 +311,11 @@ namespace Microsoft.Language.Xml
             }
             if (parent == null)
                 yield break;
-            var parentElement = (XmlNodeSyntax)parent;
+            var parentElement = (XmlNodeSyntax?)parent;
             while (parentElement != null)
             {
                 yield return parentElement;
-                parentElement = (XmlNodeSyntax)parentElement.ParentElement;
+                parentElement = (XmlNodeSyntax?)parentElement.ParentElement;
             }
         }
 
@@ -336,12 +340,12 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private static SyntaxNode GetParent(SyntaxNode node, bool ascendOutOfTrivia) => node.Parent;
+        private static SyntaxNode? GetParent(SyntaxNode node, bool ascendOutOfTrivia) => node.Parent;
 
         /// <summary>
         /// Gets the first node of type TNode that matches the predicate.
         /// </summary>
-        public TNode FirstAncestorOrSelf<TNode>(Func<TNode, bool> predicate = null, bool ascendOutOfTrivia = true)
+        public TNode? FirstAncestorOrSelf<TNode>(Func<TNode, bool>? predicate = null, bool ascendOutOfTrivia = true)
             where TNode : SyntaxNode
         {
             for (var node = this; node != null; node = GetParent(node, ascendOutOfTrivia))
@@ -361,7 +365,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodes(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodes(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -372,7 +376,7 @@ namespace Microsoft.Language.Xml
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodes(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodes(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -382,7 +386,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -393,7 +397,7 @@ namespace Microsoft.Language.Xml
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndSelf(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -403,7 +407,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndTokens(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndTokens(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -414,7 +418,7 @@ namespace Microsoft.Language.Xml
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndTokens(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndTokens(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: false);
         }
@@ -424,7 +428,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndTokensAndSelf(Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndTokensAndSelf(Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(this.FullSpan, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -435,7 +439,7 @@ namespace Microsoft.Language.Xml
         /// <param name="span">The span the node's full span must intersect.</param>
         /// <param name="descendIntoChildren">An optional function that determines if the search descends into the argument node's children.</param>
         /// <param name="descendIntoTrivia">Determines if nodes that are part of structured trivia are included in the list.</param>
-        public IEnumerable<SyntaxNode> DescendantNodesAndTokensAndSelf(TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null, bool descendIntoTrivia = false)
+        public IEnumerable<SyntaxNode> DescendantNodesAndTokensAndSelf(TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null, bool descendIntoTrivia = false)
         {
             return DescendantNodesAndTokensImpl(span, descendIntoChildren, descendIntoTrivia, includeSelf: true);
         }
@@ -454,9 +458,9 @@ namespace Microsoft.Language.Xml
 
         public bool HasTrailingTrivia => GreenNode.HasTrailingTrivia;
 
-        internal SyntaxToken GetFirstToken()
+        internal SyntaxToken? GetFirstToken()
         {
-            return ((SyntaxToken)this.GetFirstTerminal());
+            return ((SyntaxToken?)this.GetFirstTerminal());
         }
 
         internal SyntaxToken GetLastToken()
@@ -464,7 +468,7 @@ namespace Microsoft.Language.Xml
             return ((SyntaxToken)this.GetLastTerminal());
         }
 
-        public SyntaxNode GetFirstTerminal()
+        public SyntaxNode? GetFirstTerminal()
         {
             var node = this;
 
@@ -681,7 +685,8 @@ namespace Microsoft.Language.Xml
         /// modification, even if the type of a node changes.
         /// </para>
         /// </remarks>
-        public T CopyAnnotationsTo<T>(T node) where T : SyntaxNode
+        [return: NotNullIfNotNull(nameof(node))]
+        public T? CopyAnnotationsTo<T>(T node) where T : SyntaxNode
         {
             if (node == null)
             {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxNodeExtensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     public static class SyntaxNodeExtensions
@@ -284,7 +286,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         public static TSyntax WithLeadingTrivia<TSyntax>(
             this TSyntax node,
-            IEnumerable<SyntaxTrivia> trivia) where TSyntax : SyntaxNode
+            IEnumerable<SyntaxTrivia>? trivia) where TSyntax : SyntaxNode
         {
             var first = node.GetFirstToken();
             var newFirst = first.WithLeadingTrivia(trivia);
@@ -306,7 +308,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         public static TSyntax WithoutLeadingTrivia<TSyntax>(this TSyntax node) where TSyntax : SyntaxNode
         {
-            return node.WithLeadingTrivia((IEnumerable<SyntaxTrivia>)null);
+            return node.WithLeadingTrivia((IEnumerable<SyntaxTrivia>?)null);
         }
 
         /// <summary>
@@ -326,7 +328,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         public static TSyntax WithTrailingTrivia<TSyntax>(
             this TSyntax node,
-            IEnumerable<SyntaxTrivia> trivia) where TSyntax : SyntaxNode
+            IEnumerable<SyntaxTrivia>? trivia) where TSyntax : SyntaxNode
         {
             var last = node.GetLastToken();
             var newLast = last.WithTrailingTrivia(trivia);
@@ -348,7 +350,7 @@ namespace Microsoft.Language.Xml
         /// </summary>
         public static TSyntax WithoutTrailingTrivia<TSyntax>(this TSyntax node) where TSyntax : SyntaxNode
         {
-            return node.WithTrailingTrivia((IEnumerable<SyntaxTrivia>)null);
+            return node.WithTrailingTrivia((IEnumerable<SyntaxTrivia>?)null);
         }
 
         /// <summary>

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxNodeRemover.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxNodeRemover.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.Language.Xml
@@ -95,7 +96,8 @@ namespace Microsoft.Language.Xml
                 return node.FullSpan.IntersectsWith(this._searchSpan) || (this._residualTrivia != null && this._residualTrivia.Count > 0);
             }
 
-            public override SyntaxNode Visit(SyntaxNode node)
+            [return: NotNullIfNotNull(nameof(node))]
+            public override SyntaxNode? Visit(SyntaxNode? node)
             {
                 var result = node;
                 if (node != null)

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxReplacer.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxReplacer.cs
@@ -1,6 +1,12 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS8600
+#pragma warning disable CS8603
+#pragma warning disable CS8604
+
 
 namespace Microsoft.Language.Xml
 {
@@ -8,12 +14,12 @@ namespace Microsoft.Language.Xml
     {
         internal static SyntaxNode Replace<TNode>(
             SyntaxNode root,
-            IEnumerable<TNode> nodes = null,
-            Func<TNode, TNode, SyntaxNode> computeReplacementNode = null,
-            IEnumerable<SyntaxToken> tokens = null,
-            Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken = null,
-            IEnumerable<SyntaxTrivia> trivia = null,
-            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
+            IEnumerable<TNode>? nodes = null,
+            Func<TNode, TNode, SyntaxNode>? computeReplacementNode = null,
+            IEnumerable<SyntaxToken>? tokens = null,
+            Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken = null,
+            IEnumerable<SyntaxTrivia>? trivia = null,
+            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia = null)
             where TNode : SyntaxNode
         {
             var replacer = new Replacer<TNode>(
@@ -33,12 +39,12 @@ namespace Microsoft.Language.Xml
 
         internal static SyntaxToken Replace(
             SyntaxToken root,
-            IEnumerable<SyntaxNode> nodes = null,
-            Func<SyntaxNode, SyntaxNode, SyntaxNode> computeReplacementNode = null,
-            IEnumerable<SyntaxToken> tokens = null,
-            Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken = null,
-            IEnumerable<SyntaxTrivia> trivia = null,
-            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia = null)
+            IEnumerable<SyntaxNode>? nodes = null,
+            Func<SyntaxNode, SyntaxNode, SyntaxNode>? computeReplacementNode = null,
+            IEnumerable<SyntaxToken>? tokens = null,
+            Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken = null,
+            IEnumerable<SyntaxTrivia>? trivia = null,
+            Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia = null)
         {
             var replacer = new Replacer<SyntaxNode>(
                 nodes, computeReplacementNode,
@@ -57,9 +63,9 @@ namespace Microsoft.Language.Xml
 
         private class Replacer<TNode> : SyntaxRewriter where TNode : SyntaxNode
         {
-            private readonly Func<TNode, TNode, SyntaxNode> _computeReplacementNode;
-            private readonly Func<SyntaxToken, SyntaxToken, SyntaxToken> _computeReplacementToken;
-            private readonly Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> _computeReplacementTrivia;
+            private readonly Func<TNode, TNode, SyntaxNode>? _computeReplacementNode;
+            private readonly Func<SyntaxToken, SyntaxToken, SyntaxToken>? _computeReplacementToken;
+            private readonly Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? _computeReplacementTrivia;
 
             private readonly HashSet<SyntaxNode> _nodeSet;
             private readonly HashSet<SyntaxToken> _tokenSet;
@@ -70,12 +76,12 @@ namespace Microsoft.Language.Xml
             private readonly bool _shouldVisitTrivia;
 
             public Replacer(
-                IEnumerable<TNode> nodes,
-                Func<TNode, TNode, SyntaxNode> computeReplacementNode,
-                IEnumerable<SyntaxToken> tokens,
-                Func<SyntaxToken, SyntaxToken, SyntaxToken> computeReplacementToken,
-                IEnumerable<SyntaxTrivia> trivia,
-                Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia> computeReplacementTrivia)
+                IEnumerable<TNode>? nodes,
+                Func<TNode, TNode, SyntaxNode>? computeReplacementNode,
+                IEnumerable<SyntaxToken>? tokens,
+                Func<SyntaxToken, SyntaxToken, SyntaxToken>? computeReplacementToken,
+                IEnumerable<SyntaxTrivia>? trivia,
+                Func<SyntaxTrivia, SyntaxTrivia, SyntaxTrivia>? computeReplacementTrivia)
             {
                 _computeReplacementNode = computeReplacementNode;
                 _computeReplacementToken = computeReplacementToken;
@@ -154,9 +160,9 @@ namespace Microsoft.Language.Xml
                 return false;
             }
 
-            public override SyntaxNode Visit(SyntaxNode node)
+            public override SyntaxNode? Visit(SyntaxNode? node)
             {
-                SyntaxNode rewritten = node;
+                SyntaxNode? rewritten = node;
 
                 if (node != null)
                 {
@@ -256,9 +262,10 @@ namespace Microsoft.Language.Xml
                 return false;
             }
 
-            public override SyntaxNode Visit(SyntaxNode node)
+            [return: NotNullIfNotNull(nameof(node))]
+            public override SyntaxNode? Visit(SyntaxNode? node)
             {
-                SyntaxNode rewritten = node;
+                SyntaxNode? rewritten = node;
 
                 if (node != null)
                 {
@@ -299,7 +306,7 @@ namespace Microsoft.Language.Xml
                 _newNodes = replacementNodes;
             }
 
-            public override SyntaxNode Visit(SyntaxNode node)
+            public override SyntaxNode? Visit(SyntaxNode? node)
             {
                 if (node == _originalNode)
                 {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxRewriter.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Language.Xml
                 var item = list[i];
                 var visitedItem = this.Visit(item);
 
-                SyntaxToken separator = null;
-                SyntaxToken visitedSeparator = null;
+                SyntaxToken? separator = null;
+                SyntaxToken? visitedSeparator = null;
 
                 if (i < separatorCount)
                 {
@@ -106,7 +106,7 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlDocument(XmlDocumentSyntax node)
         {
             bool anyChanges = false;
-            var newDeclaration = ((XmlDeclarationSyntax)Visit(node.Prologue));
+            var newDeclaration = ((XmlDeclarationSyntax?)Visit(node.Prologue));
             if (node.Prologue != newDeclaration)
             {
                 anyChanges = true;
@@ -118,7 +118,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newRoot = ((XmlNodeSyntax)Visit(node.Body));
+            var newRoot = ((XmlNodeSyntax?)Visit(node.Body));
             if (node.Body != newRoot)
             {
                 anyChanges = true;
@@ -161,37 +161,37 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlDeclaration(XmlDeclarationSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanQuestionToken = ((PunctuationSyntax)Visit(node.LessThanQuestionToken));
+            var newLessThanQuestionToken = ((PunctuationSyntax?)Visit(node.LessThanQuestionToken));
             if (node.LessThanQuestionToken != newLessThanQuestionToken)
             {
                 anyChanges = true;
             }
 
-            var newXmlKeyword = ((KeywordSyntax)Visit(node.XmlKeyword));
+            var newXmlKeyword = ((KeywordSyntax?)Visit(node.XmlKeyword));
             if (node.XmlKeyword != newXmlKeyword)
             {
                 anyChanges = true;
             }
 
-            var newVersion = ((XmlDeclarationOptionSyntax)Visit(node.Version));
+            var newVersion = ((XmlDeclarationOptionSyntax?)Visit(node.Version));
             if (node.Version != newVersion)
             {
                 anyChanges = true;
             }
 
-            var newEncoding = ((XmlDeclarationOptionSyntax)Visit(node.Encoding));
+            var newEncoding = ((XmlDeclarationOptionSyntax?)Visit(node.Encoding));
             if (node.Encoding != newEncoding)
             {
                 anyChanges = true;
             }
 
-            var newStandalone = ((XmlDeclarationOptionSyntax)Visit(node.Standalone));
+            var newStandalone = ((XmlDeclarationOptionSyntax?)Visit(node.Standalone));
             if (node.Standalone != newStandalone)
             {
                 anyChanges = true;
             }
 
-            var newQuestionGreaterThanToken = ((PunctuationSyntax)Visit(node.QuestionGreaterThanToken));
+            var newQuestionGreaterThanToken = ((PunctuationSyntax?)Visit(node.QuestionGreaterThanToken));
             if (node.QuestionGreaterThanToken != newQuestionGreaterThanToken)
             {
                 anyChanges = true;
@@ -216,19 +216,19 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlDeclarationOption(XmlDeclarationOptionSyntax node)
         {
             bool anyChanges = false;
-            var newName = ((XmlNameTokenSyntax)Visit(node.NameNode));
+            var newName = ((XmlNameTokenSyntax?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
             }
 
-            var newEquals = ((PunctuationSyntax)Visit(node.Equals));
+            var newEquals = ((PunctuationSyntax?)Visit(node.Equals));
             if (node.Equals != newEquals)
             {
                 anyChanges = true;
             }
 
-            var newValue = ((XmlStringSyntax)Visit(node.Value));
+            var newValue = ((XmlStringSyntax?)Visit(node.Value));
             if (node.Value != newValue)
             {
                 anyChanges = true;
@@ -247,7 +247,7 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlElement(XmlElementSyntax node)
         {
             bool anyChanges = false;
-            var newStartTag = ((XmlElementStartTagSyntax)Visit(node.StartTag));
+            var newStartTag = ((XmlElementStartTagSyntax?)Visit(node.StartTag));
             if (node.StartTag != newStartTag)
             {
                 anyChanges = true;
@@ -259,7 +259,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newEndTag = ((XmlElementEndTagSyntax)Visit(node.EndTag));
+            var newEndTag = ((XmlElementEndTagSyntax?)Visit(node.EndTag));
             if (node.EndTag != newEndTag)
             {
                 anyChanges = true;
@@ -297,13 +297,13 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlElementStartTag(XmlElementStartTagSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanToken = ((PunctuationSyntax)Visit(node.LessThanToken));
+            var newLessThanToken = ((PunctuationSyntax?)Visit(node.LessThanToken));
             if (node.LessThanToken != newLessThanToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
@@ -315,7 +315,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newGreaterThanToken = ((PunctuationSyntax)Visit(node.GreaterThanToken));
+            var newGreaterThanToken = ((PunctuationSyntax?)Visit(node.GreaterThanToken));
             if (node.GreaterThanToken != newGreaterThanToken)
             {
                 anyChanges = true;
@@ -334,19 +334,19 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlElementEndTag(XmlElementEndTagSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanSlashToken = ((PunctuationSyntax)Visit(node.LessThanSlashToken));
+            var newLessThanSlashToken = ((PunctuationSyntax?)Visit(node.LessThanSlashToken));
             if (node.LessThanSlashToken != newLessThanSlashToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
             }
 
-            var newGreaterThanToken = ((PunctuationSyntax)Visit(node.GreaterThanToken));
+            var newGreaterThanToken = ((PunctuationSyntax?)Visit(node.GreaterThanToken));
             if (node.GreaterThanToken != newGreaterThanToken)
             {
                 anyChanges = true;
@@ -365,13 +365,13 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlEmptyElement(XmlEmptyElementSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanToken = ((PunctuationSyntax)Visit(node.LessThanToken));
+            var newLessThanToken = ((PunctuationSyntax?)Visit(node.LessThanToken));
             if (node.LessThanToken != newLessThanToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameSyntax)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
@@ -383,7 +383,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newSlashGreaterThanToken = ((PunctuationSyntax)Visit(node.SlashGreaterThanToken));
+            var newSlashGreaterThanToken = ((PunctuationSyntax?)Visit(node.SlashGreaterThanToken));
             if (node.SlashGreaterThanToken != newSlashGreaterThanToken)
             {
                 anyChanges = true;
@@ -402,19 +402,19 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlAttribute(XmlAttributeSyntax node)
         {
             bool anyChanges = false;
-            var newName = ((XmlNameSyntax)Visit(node.NameNode));
+            var newName = ((XmlNameSyntax?)Visit(node.NameNode));
             if (node.NameNode != newName)
             {
                 anyChanges = true;
             }
 
-            var newEqualsToken = ((PunctuationSyntax)Visit(node.Equals));
+            var newEqualsToken = ((PunctuationSyntax?)Visit(node.Equals));
             if (node.Equals != newEqualsToken)
             {
                 anyChanges = true;
             }
 
-            var newValue = ((XmlNodeSyntax)Visit(node.ValueNode));
+            var newValue = ((XmlNodeSyntax?)Visit(node.ValueNode));
             if (node.ValueNode != newValue)
             {
                 anyChanges = true;
@@ -433,7 +433,7 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlString(XmlStringSyntax node)
         {
             bool anyChanges = false;
-            var newStartQuoteToken = ((PunctuationSyntax)Visit(node.StartQuoteToken));
+            var newStartQuoteToken = ((PunctuationSyntax?)Visit(node.StartQuoteToken));
             if (node.StartQuoteToken != newStartQuoteToken)
             {
                 anyChanges = true;
@@ -445,7 +445,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newEndQuoteToken = ((PunctuationSyntax)Visit(node.EndQuoteToken));
+            var newEndQuoteToken = ((PunctuationSyntax?)Visit(node.EndQuoteToken));
             if (node.EndQuoteToken != newEndQuoteToken)
             {
                 anyChanges = true;
@@ -464,13 +464,13 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlName(XmlNameSyntax node)
         {
             bool anyChanges = false;
-            var newPrefix = ((XmlPrefixSyntax)Visit(node.PrefixNode));
+            var newPrefix = ((XmlPrefixSyntax?)Visit(node.PrefixNode));
             if (node.PrefixNode != newPrefix)
             {
                 anyChanges = true;
             }
 
-            var newLocalName = ((XmlNameTokenSyntax)Visit(node.LocalNameNode));
+            var newLocalName = ((XmlNameTokenSyntax?)Visit(node.LocalNameNode));
             if (node.LocalNameNode != newLocalName)
             {
                 anyChanges = true;
@@ -489,13 +489,13 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlPrefix(XmlPrefixSyntax node)
         {
             bool anyChanges = false;
-            var newName = ((XmlNameTokenSyntax)Visit(node.Name));
+            var newName = ((XmlNameTokenSyntax?)Visit(node.Name));
             if (node.Name != newName)
             {
                 anyChanges = true;
             }
 
-            var newColonToken = ((PunctuationSyntax)Visit(node.ColonToken));
+            var newColonToken = ((PunctuationSyntax?)Visit(node.ColonToken));
             if (node.ColonToken != newColonToken)
             {
                 anyChanges = true;
@@ -514,7 +514,7 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlComment(XmlCommentSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanExclamationMinusMinusToken = ((PunctuationSyntax)Visit(node.BeginComment));
+            var newLessThanExclamationMinusMinusToken = ((PunctuationSyntax?)Visit(node.BeginComment));
             if (node.BeginComment != newLessThanExclamationMinusMinusToken)
             {
                 anyChanges = true;
@@ -526,7 +526,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newMinusMinusGreaterThanToken = ((PunctuationSyntax)Visit(node.EndComment));
+            var newMinusMinusGreaterThanToken = ((PunctuationSyntax?)Visit(node.EndComment));
             if (node.EndComment != newMinusMinusGreaterThanToken)
             {
                 anyChanges = true;
@@ -545,13 +545,13 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlProcessingInstruction(XmlProcessingInstructionSyntax node)
         {
             bool anyChanges = false;
-            var newLessThanQuestionToken = ((PunctuationSyntax)Visit(node.LessThanQuestionToken));
+            var newLessThanQuestionToken = ((PunctuationSyntax?)Visit(node.LessThanQuestionToken));
             if (node.LessThanQuestionToken != newLessThanQuestionToken)
             {
                 anyChanges = true;
             }
 
-            var newName = ((XmlNameTokenSyntax)Visit(node.Name));
+            var newName = ((XmlNameTokenSyntax?)Visit(node.Name));
             if (node.Name != newName)
             {
                 anyChanges = true;
@@ -563,7 +563,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newQuestionGreaterThanToken = ((PunctuationSyntax)Visit(node.QuestionGreaterThanToken));
+            var newQuestionGreaterThanToken = ((PunctuationSyntax?)Visit(node.QuestionGreaterThanToken));
             if (node.QuestionGreaterThanToken != newQuestionGreaterThanToken)
             {
                 anyChanges = true;
@@ -582,7 +582,7 @@ namespace Microsoft.Language.Xml
         public override SyntaxNode VisitXmlCDataSection(XmlCDataSectionSyntax node)
         {
             bool anyChanges = false;
-            var newBeginCDataToken = ((PunctuationSyntax)Visit(node.BeginCData));
+            var newBeginCDataToken = ((PunctuationSyntax?)Visit(node.BeginCData));
             if (node.BeginCData != newBeginCDataToken)
             {
                 anyChanges = true;
@@ -594,7 +594,7 @@ namespace Microsoft.Language.Xml
                 anyChanges = true;
             }
 
-            var newEndCDataToken = ((PunctuationSyntax)Visit(node.EndCData));
+            var newEndCDataToken = ((PunctuationSyntax?)Visit(node.EndCData));
             if (node.EndCData != newEndCDataToken)
             {
                 anyChanges = true;

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxToken.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Language.Xml
         internal abstract class Green : GreenNode
         {
             public string Text { get; }
-            public GreenNode LeadingTrivia { get; }
-            public GreenNode TrailingTrivia { get; }
+            public GreenNode? LeadingTrivia { get; }
+            public GreenNode? TrailingTrivia { get; }
 
-            internal Green(SyntaxKind tokenKind, string text, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(SyntaxKind tokenKind, string text, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(tokenKind, text.Length)
             {
                 Text = text;
@@ -26,7 +26,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(trailingTrivia);
             }
 
-            internal Green(SyntaxKind tokenKind, string text, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxKind tokenKind, string text, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(tokenKind, text.Length, diagnostics, annotations)
             {
                 Text = text;
@@ -57,13 +57,13 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            internal override sealed GreenNode GetLeadingTrivia() => LeadingTrivia;
+            internal override sealed GreenNode? GetLeadingTrivia() => LeadingTrivia;
             public override int GetLeadingTriviaWidth() => LeadingTrivia == null ? 0 : LeadingTrivia.FullWidth;
-            internal override sealed GreenNode GetTrailingTrivia() => TrailingTrivia;
+            internal override sealed GreenNode? GetTrailingTrivia() => TrailingTrivia;
             public override int GetTrailingTriviaWidth() => TrailingTrivia == null ? 0 : TrailingTrivia.FullWidth;
 
-            public abstract SyntaxToken.Green WithLeadingTrivia(GreenNode trivia);
-            public abstract SyntaxToken.Green WithTrailingTrivia(GreenNode trivia);
+            public abstract SyntaxToken.Green WithLeadingTrivia(GreenNode? trivia);
+            public abstract SyntaxToken.Green WithTrailingTrivia(GreenNode? trivia);
 
             protected override sealed int GetSlotCount() => 0;
 
@@ -92,7 +92,7 @@ namespace Microsoft.Language.Xml
                 }
 
                 var oldTrivia = new InternalSyntax.SyntaxList<GreenNode>(token.GetLeadingTrivia());
-                GreenNode leadingTrivia;
+                GreenNode? leadingTrivia;
                 if (oldTrivia.Node == null)
                 {
                     leadingTrivia = newTrivia.Node;
@@ -121,7 +121,7 @@ namespace Microsoft.Language.Xml
                 }
 
                 var oldTrivia = new InternalSyntax.SyntaxList<GreenNode>(token.GetTrailingTrivia());
-                GreenNode trailingTrivia;
+                GreenNode? trailingTrivia;
                 if (oldTrivia.Node == null)
                 {
                     trailingTrivia = newTrivia.Node;
@@ -140,7 +140,7 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        internal SyntaxToken(Green green, SyntaxNode parent, int position)
+        internal SyntaxToken(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
         }
@@ -174,19 +174,19 @@ namespace Microsoft.Language.Xml
             return new SyntaxTriviaList(trailingGreen.CreateRed(this, trailingPosition), trailingPosition, index);
         }
 
-        internal abstract SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia);
-        internal abstract SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia);
+        internal abstract SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia);
+        internal abstract SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia);
 
         public SyntaxToken WithLeadingTrivia(SyntaxNode trivia) => WithLeadingTriviaCore(trivia);
         public SyntaxToken WithTrailingTrivia(SyntaxNode trivia) => WithTrailingTriviaCore(trivia);
 
-        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia> trivia)
+        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             var greenList = trivia?.Select(t => t.GreenNode);
             return WithLeadingTriviaCore(GreenNode.CreateList(greenList)?.CreateRed());
         }
 
-        public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia> trivia)
+        public SyntaxToken WithTrailingTrivia(IEnumerable<SyntaxTrivia>? trivia)
         {
             var greenList = trivia?.Select(t => t.GreenNode);
             return WithTrailingTriviaCore(GreenNode.CreateList(greenList)?.CreateRed());

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxTrivia.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Language.Xml
                 Text = text;
             }
 
-            internal Green(SyntaxKind kind, string text, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxKind kind, string text, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(kind, text.Length, diagnostics, annotations)
             {
                 Text = text;
@@ -43,14 +43,14 @@ namespace Microsoft.Language.Xml
                 throw new InvalidOperationException();
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new SyntaxTrivia(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new SyntaxTrivia(this, parent, position);
 
             internal override GreenNode Accept(InternalSyntax.SyntaxVisitor visitor)
             {
                 return visitor.VisitSyntaxTrivia(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(Kind, Text, diagnostics, GetAnnotations());
             }
@@ -65,7 +65,7 @@ namespace Microsoft.Language.Xml
 
         public string Text => GreenNode.Text;
 
-        internal SyntaxTrivia(Green green, SyntaxNode parent, int position)
+        internal SyntaxTrivia(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
         }

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxTriviaList.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxTriviaList.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Language.Xml
 {
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using InternalSyntax;
 
     /// <summary>
@@ -456,7 +457,7 @@ namespace Microsoft.Language.Xml
             return !left.Equals(right);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return (obj is SyntaxTriviaList) && Equals((SyntaxTriviaList)obj);
         }
@@ -556,7 +557,7 @@ namespace Microsoft.Language.Xml
                 return _list.GetHashCode();
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is Reversed && Equals((Reversed)obj);
             }
@@ -662,7 +663,7 @@ namespace Microsoft.Language.Xml
             private int _count;
 
             private int _index;
-            private SyntaxNode _current;
+            private SyntaxNode? _current;
             private int _position;
 
             internal Enumerator(in SyntaxTriviaList list)
@@ -717,6 +718,7 @@ namespace Microsoft.Language.Xml
                 InitializeFrom(trailing, index, trailingPosition);
             }
 
+            [MemberNotNullWhen(true, nameof(_current))]
             public bool MoveNext()
             {
                 int newIndex = _index + 1;
@@ -751,7 +753,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            internal bool TryMoveNextAndGetCurrent(out SyntaxTrivia current)
+            internal bool TryMoveNextAndGetCurrent([NotNullWhen(true)] out SyntaxTrivia? current)
             {
                 if (!MoveNext())
                 {

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxTriviaListBuilder.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxTriviaListBuilder.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;

--- a/src/Microsoft.Language.Xml/Syntax/SyntaxVisitor.cs
+++ b/src/Microsoft.Language.Xml/Syntax/SyntaxVisitor.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Language.Xml
 {
     public abstract class SyntaxVisitor
     {
-        public virtual SyntaxNode Visit(SyntaxNode node)
+        [return: NotNullIfNotNull(nameof(node))]
+        public virtual SyntaxNode? Visit(SyntaxNode? node)
         {
             if (node != null)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlAttributeSyntax.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly XmlNameSyntax.Green nameNode;
-            readonly SyntaxToken.Green equalsSyntax;
-            readonly XmlNodeSyntax.Green valueNode;
+            readonly XmlNameSyntax.Green? nameNode;
+            readonly SyntaxToken.Green? equalsSyntax;
+            readonly XmlNodeSyntax.Green? valueNode;
 
-            internal XmlNameSyntax.Green NameNode => nameNode;
-            internal new SyntaxToken.Green Equals => equalsSyntax;
-            internal XmlNodeSyntax.Green ValueNode => valueNode;
+            internal XmlNameSyntax.Green? NameNode => nameNode;
+            internal new SyntaxToken.Green? Equals => equalsSyntax;
+            internal XmlNodeSyntax.Green? ValueNode => valueNode;
 
-            internal Green(XmlNameSyntax.Green nameNode, SyntaxToken.Green equalsSyntax, XmlNodeSyntax.Green valueNode)
+            internal Green(XmlNameSyntax.Green? nameNode, SyntaxToken.Green? equalsSyntax, XmlNodeSyntax.Green? valueNode)
                 : base(SyntaxKind.XmlAttribute)
             {
                 this.SlotCount = 3;
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(valueNode);
             }
 
-            internal Green(XmlNameSyntax.Green nameNode, SyntaxToken.Green equalsSyntax, XmlNodeSyntax.Green valueNode, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlNameSyntax.Green? nameNode, SyntaxToken.Green? equalsSyntax, XmlNodeSyntax.Green? valueNode, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlAttribute, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -40,9 +40,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(valueNode);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlAttributeSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlAttributeSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlAttribute(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(nameNode, equalsSyntax, valueNode, diagnostics, GetAnnotations());
             }
@@ -69,21 +69,21 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        XmlNameSyntax nameNode;
-        PunctuationSyntax equalsSyntax;
-        XmlStringSyntax valueNode;
+        XmlNameSyntax? nameNode;
+        PunctuationSyntax? equalsSyntax;
+        XmlStringSyntax? valueNode;
 
-        public XmlNameSyntax NameNode => GetRed(ref nameNode, 0);
-        public new PunctuationSyntax Equals => GetRed(ref equalsSyntax, 1);
-        public XmlStringSyntax ValueNode => GetRed(ref valueNode, 2);
+        public XmlNameSyntax? NameNode => GetRed(ref nameNode, 0);
+        public new PunctuationSyntax? Equals => GetRed(ref equalsSyntax, 1);
+        public XmlStringSyntax? ValueNode => GetRed(ref valueNode, 2);
 
-        internal XmlAttributeSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlAttributeSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        public string Name => NameNode?.FullName;
+        public string? Name => NameNode?.FullName;
 
         public bool IsNamespaceDeclaration => string.Equals(NameNode?.Prefix, "xmlns", StringComparison.Ordinal);
 
@@ -95,7 +95,7 @@ namespace Microsoft.Language.Xml
         /// <seealso href="https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-line-ends">2.2.12 [XML] Section 3.3.3</seealso/>
         /// <seealso href="https://learn.microsoft.com/en-us/openspecs/ie_standards/ms-xml/389b8ef1-e19e-40ac-80de-eec2cd0c58ae">2.11 [XML} End-of-Line Handling</seealso/>
         /// </remarks>
-        public string Value
+        public string? Value
         {
             get
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlAttribute(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlAttributeSyntax Update(XmlNameSyntax name, PunctuationSyntax equalsToken, XmlStringSyntax value)
+        public XmlAttributeSyntax Update(XmlNameSyntax? name, PunctuationSyntax? equalsToken, XmlStringSyntax? value)
         {
             if (name != this.NameNode || equalsToken != this.Equals || value != this.ValueNode)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlCDataSectionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlCDataSectionSyntax.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green beginCData;
-            readonly GreenNode value;
-            readonly PunctuationSyntax.Green endCData;
+            readonly PunctuationSyntax.Green? beginCData;
+            readonly GreenNode? value;
+            readonly PunctuationSyntax.Green? endCData;
 
-            internal PunctuationSyntax.Green BeginCData => beginCData;
+            internal PunctuationSyntax.Green? BeginCData => beginCData;
             internal InternalSyntax.SyntaxList<GreenNode> TextTokens => value;
-            internal PunctuationSyntax.Green EndCData => endCData;
+            internal PunctuationSyntax.Green? EndCData => endCData;
 
-            internal Green(PunctuationSyntax.Green beginCData, GreenNode value, PunctuationSyntax.Green endCData)
+            internal Green(PunctuationSyntax.Green? beginCData, GreenNode? value, PunctuationSyntax.Green? endCData)
                 : base(SyntaxKind.XmlCDataSection)
             {
                 this.SlotCount = 3;
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endCData);
             }
 
-            internal Green(PunctuationSyntax.Green beginCData, GreenNode value, PunctuationSyntax.Green endCData, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(PunctuationSyntax.Green? beginCData, GreenNode? value, PunctuationSyntax.Green? endCData, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlCDataSection, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -40,9 +40,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endCData);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlCDataSectionSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlCDataSectionSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlCDataSection(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(beginCData, value, endCData, diagnostics, GetAnnotations());
             }
@@ -69,15 +69,15 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        PunctuationSyntax beginCData;
-        SyntaxNode textTokens;
-        PunctuationSyntax endCData;
+        PunctuationSyntax? beginCData;
+        SyntaxNode? textTokens;
+        PunctuationSyntax? endCData;
 
-        public PunctuationSyntax BeginCData => GetRed(ref beginCData, 0);
+        public PunctuationSyntax? BeginCData => GetRed(ref beginCData, 0);
         public SyntaxList<SyntaxNode> TextTokens => new SyntaxList<SyntaxNode>(GetRed(ref textTokens, 1));
-        public PunctuationSyntax EndCData => GetRed(ref endCData, 2);
+        public PunctuationSyntax? EndCData => GetRed(ref endCData, 2);
 
-        internal XmlCDataSectionSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlCDataSectionSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -90,7 +90,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlCDataSection(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -101,7 +101,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlCommentSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlCommentSyntax.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green beginComment;
-            readonly GreenNode content;
-            readonly PunctuationSyntax.Green endComment;
+            readonly PunctuationSyntax.Green? beginComment;
+            readonly GreenNode? content;
+            readonly PunctuationSyntax.Green? endComment;
 
-            internal PunctuationSyntax.Green BeginComment => beginComment;
-            internal GreenNode Content => content;
-            internal PunctuationSyntax.Green EndComment => endComment;
+            internal PunctuationSyntax.Green? BeginComment => beginComment;
+            internal GreenNode? Content => content;
+            internal PunctuationSyntax.Green? EndComment => endComment;
 
-            internal Green(PunctuationSyntax.Green beginComment, GreenNode content, PunctuationSyntax.Green endComment)
+            internal Green(PunctuationSyntax.Green? beginComment, GreenNode? content, PunctuationSyntax.Green? endComment)
                 : base(SyntaxKind.XmlComment)
             {
                 this.SlotCount = 3;
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endComment);
             }
 
-            internal Green(PunctuationSyntax.Green beginComment, GreenNode content, PunctuationSyntax.Green endComment, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(PunctuationSyntax.Green? beginComment, GreenNode? content, PunctuationSyntax.Green? endComment, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlComment, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -40,9 +40,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endComment);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlCommentSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlCommentSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlNode(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(beginComment, content, endComment, diagnostics, GetAnnotations());
             }
@@ -69,15 +69,15 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        PunctuationSyntax beginComment;
-        SyntaxNode content;
-        PunctuationSyntax endComment;
+        PunctuationSyntax? beginComment;
+        SyntaxNode? content;
+        PunctuationSyntax? endComment;
 
-        public PunctuationSyntax BeginComment => GetRed(ref beginComment, 0);
+        public PunctuationSyntax? BeginComment => GetRed(ref beginComment, 0);
         public SyntaxList<SyntaxNode> Content => new SyntaxList<SyntaxNode>(GetRed(ref content, 1));
-        public PunctuationSyntax EndComment => GetRed(ref endComment, 2);
+        public PunctuationSyntax? EndComment => GetRed(ref endComment, 2);
 
-        internal XmlCommentSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlCommentSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -90,7 +90,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlComment(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -101,7 +101,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlContentExtensions.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlContentExtensions.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     public static class XmlContextExtensions
@@ -28,7 +30,7 @@ namespace Microsoft.Language.Xml
             return @this[last - i];
         }
 
-        internal static int MatchEndElement(this List<XmlContext> @this, XmlNameSyntax.Green name)
+        internal static int MatchEndElement(this List<XmlContext> @this, XmlNameSyntax.Green? name)
         {
             Debug.Assert(name == null || name.Kind == SyntaxKind.XmlName);
             var last = @this.Count - 1;

--- a/src/Microsoft.Language.Xml/Syntax/XmlContext.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlContext.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Language.Xml
 
     internal readonly struct XmlContext
     {
-        private readonly XmlElementStartTagSyntax.Green _start;
+        private readonly XmlElementStartTagSyntax.Green? _start;
         private readonly InternalSyntax.SyntaxListBuilder<XmlNodeSyntax.Green> _content;
         private readonly SyntaxListPool _pool;
 
-        public XmlContext(SyntaxListPool pool, XmlElementStartTagSyntax.Green start)
+        public XmlContext(SyntaxListPool pool, XmlElementStartTagSyntax.Green? start)
         {
             _pool = pool;
             _start = start;
@@ -27,7 +27,7 @@ namespace Microsoft.Language.Xml
             _content.Add(xml);
         }
 
-        public XmlElementStartTagSyntax.Green StartElement
+        public XmlElementStartTagSyntax.Green? StartElement
         {
             get
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlDeclarationOptionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDeclarationOptionSyntax.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly XmlNameTokenSyntax.Green name;
-            readonly PunctuationSyntax.Green equals;
-            readonly XmlStringSyntax.Green value;
+            readonly XmlNameTokenSyntax.Green? name;
+            readonly PunctuationSyntax.Green? equals;
+            readonly XmlStringSyntax.Green? value;
 
-            internal XmlNameTokenSyntax.Green Name => name;
-            internal new PunctuationSyntax.Green Equals => equals;
-            internal XmlStringSyntax.Green Value => value;
+            internal XmlNameTokenSyntax.Green? Name => name;
+            internal new PunctuationSyntax.Green? Equals => equals;
+            internal XmlStringSyntax.Green? Value => value;
 
-            internal Green(XmlNameTokenSyntax.Green name, PunctuationSyntax.Green equals, XmlStringSyntax.Green value)
+            internal Green(XmlNameTokenSyntax.Green? name, PunctuationSyntax.Green? equals, XmlStringSyntax.Green? value)
                 : base(SyntaxKind.XmlDeclarationOption)
             {
                 this.SlotCount = 3;
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(value);
             }
 
-            internal Green(XmlNameTokenSyntax.Green name, PunctuationSyntax.Green equals, XmlStringSyntax.Green value, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlNameTokenSyntax.Green? name, PunctuationSyntax.Green? equals, XmlStringSyntax.Green? value, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlDeclarationOption, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -40,9 +40,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(value);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlDeclarationOptionSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlDeclarationOptionSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlDeclarationOption(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(name, equals, value, diagnostics, GetAnnotations());
             }
@@ -71,17 +71,17 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)GreenNode;
 
-        XmlNameTokenSyntax nameNode;
-        PunctuationSyntax equals;
-        XmlStringSyntax value;
+        XmlNameTokenSyntax? nameNode;
+        PunctuationSyntax? equals;
+        XmlStringSyntax? value;
 
-        public XmlNameTokenSyntax NameNode => GetRed(ref nameNode, 0);
-        public new PunctuationSyntax Equals => GetRed(ref equals, 1);
-        public XmlStringSyntax Value => GetRed(ref value, 2);
+        public XmlNameTokenSyntax? NameNode => GetRed(ref nameNode, 0);
+        public new PunctuationSyntax? Equals => GetRed(ref equals, 1);
+        public XmlStringSyntax? Value => GetRed(ref value, 2);
 
-        public string Name => NameNode?.Name;
+        public string? Name => NameNode?.Name;
 
-        internal XmlDeclarationOptionSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlDeclarationOptionSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -92,7 +92,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlDeclarationOption(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlDeclarationSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDeclarationSyntax.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green lessThanQuestionToken;
-            readonly GreenNode xmlKeyword;
-            readonly XmlDeclarationOptionSyntax.Green version;
-            readonly XmlDeclarationOptionSyntax.Green encoding;
-            readonly XmlDeclarationOptionSyntax.Green standalone;
-            readonly PunctuationSyntax.Green questionGreaterThanToken;
+            readonly PunctuationSyntax.Green? lessThanQuestionToken;
+            readonly GreenNode? xmlKeyword;
+            readonly XmlDeclarationOptionSyntax.Green? version;
+            readonly XmlDeclarationOptionSyntax.Green? encoding;
+            readonly XmlDeclarationOptionSyntax.Green? standalone;
+            readonly PunctuationSyntax.Green? questionGreaterThanToken;
 
-            internal PunctuationSyntax.Green LessThanQuestionToken => lessThanQuestionToken;
-            internal GreenNode XmlKeyword => xmlKeyword;
-            internal XmlDeclarationOptionSyntax.Green Version => version;
-            internal XmlDeclarationOptionSyntax.Green Encoding => encoding;
-            internal XmlDeclarationOptionSyntax.Green Standalone => standalone;
-            internal PunctuationSyntax.Green QuestionGreaterThanToken => questionGreaterThanToken;
+            internal PunctuationSyntax.Green? LessThanQuestionToken => lessThanQuestionToken;
+            internal GreenNode? XmlKeyword => xmlKeyword;
+            internal XmlDeclarationOptionSyntax.Green? Version => version;
+            internal XmlDeclarationOptionSyntax.Green? Encoding => encoding;
+            internal XmlDeclarationOptionSyntax.Green? Standalone => standalone;
+            internal PunctuationSyntax.Green? QuestionGreaterThanToken => questionGreaterThanToken;
 
-            internal Green(PunctuationSyntax.Green lessThanQuestionToken,
-                           GreenNode xmlKeyword, XmlDeclarationOptionSyntax.Green version,
-                           XmlDeclarationOptionSyntax.Green encoding,
-                           XmlDeclarationOptionSyntax.Green standalone,
-                           PunctuationSyntax.Green questionGreaterThanToken)
+            internal Green(PunctuationSyntax.Green? lessThanQuestionToken,
+                           GreenNode? xmlKeyword, XmlDeclarationOptionSyntax.Green? version,
+                           XmlDeclarationOptionSyntax.Green? encoding,
+                           XmlDeclarationOptionSyntax.Green? standalone,
+                           PunctuationSyntax.Green? questionGreaterThanToken)
                 : base(SyntaxKind.XmlDeclaration)
             {
                 this.SlotCount = 6;
@@ -47,12 +47,12 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(questionGreaterThanToken);
             }
 
-            internal Green(PunctuationSyntax.Green lessThanQuestionToken,
-                           GreenNode xmlKeyword, XmlDeclarationOptionSyntax.Green version,
-                           XmlDeclarationOptionSyntax.Green encoding,
-                           XmlDeclarationOptionSyntax.Green standalone,
-                           PunctuationSyntax.Green questionGreaterThanToken,
-                           DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(PunctuationSyntax.Green? lessThanQuestionToken,
+                           GreenNode? xmlKeyword, XmlDeclarationOptionSyntax.Green? version,
+                           XmlDeclarationOptionSyntax.Green? encoding,
+                           XmlDeclarationOptionSyntax.Green? standalone,
+                           PunctuationSyntax.Green? questionGreaterThanToken,
+                           DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlDeclaration, diagnostics, annotations)
             {
                 this.SlotCount = 6;
@@ -70,9 +70,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(questionGreaterThanToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlDeclarationSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlDeclarationSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlDeclaration(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(lessThanQuestionToken, xmlKeyword, version, encoding, standalone, questionGreaterThanToken, diagnostics, GetAnnotations());
             }
@@ -104,21 +104,21 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        PunctuationSyntax lessThanQuestionToken;
-        SyntaxToken xmlKeyword;
-        XmlDeclarationOptionSyntax version;
-        XmlDeclarationOptionSyntax encoding;
-        XmlDeclarationOptionSyntax standalone;
-        PunctuationSyntax questionGreaterThanToken;
+        PunctuationSyntax? lessThanQuestionToken;
+        SyntaxToken? xmlKeyword;
+        XmlDeclarationOptionSyntax? version;
+        XmlDeclarationOptionSyntax? encoding;
+        XmlDeclarationOptionSyntax? standalone;
+        PunctuationSyntax? questionGreaterThanToken;
 
-        public PunctuationSyntax LessThanQuestionToken => GetRed(ref lessThanQuestionToken, 0);
-        public SyntaxToken XmlKeyword => GetRed(ref xmlKeyword, 1);
-        public XmlDeclarationOptionSyntax Version => GetRed(ref version, 2);
-        public XmlDeclarationOptionSyntax Encoding => GetRed(ref encoding, 3);
-        public XmlDeclarationOptionSyntax Standalone => GetRed(ref standalone, 4);
-        public PunctuationSyntax QuestionGreaterThanToken => GetRed(ref questionGreaterThanToken, 5);
+        public PunctuationSyntax? LessThanQuestionToken => GetRed(ref lessThanQuestionToken, 0);
+        public SyntaxToken? XmlKeyword => GetRed(ref xmlKeyword, 1);
+        public XmlDeclarationOptionSyntax? Version => GetRed(ref version, 2);
+        public XmlDeclarationOptionSyntax? Encoding => GetRed(ref encoding, 3);
+        public XmlDeclarationOptionSyntax? Standalone => GetRed(ref standalone, 4);
+        public PunctuationSyntax? QuestionGreaterThanToken => GetRed(ref questionGreaterThanToken, 5);
 
-        internal XmlDeclarationSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlDeclarationSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -129,7 +129,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlDeclaration(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -143,7 +143,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlDocumentSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlDocumentSyntax.cs
@@ -9,21 +9,21 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly XmlDeclarationSyntax.Green prologue;
-            readonly GreenNode precedingMisc;
-            readonly XmlNodeSyntax.Green body;
-            readonly GreenNode followingMisc;
-            readonly SkippedTokensTriviaSyntax.Green skippedTokens;
-            readonly SyntaxToken.Green eof;
+            readonly XmlDeclarationSyntax.Green? prologue;
+            readonly GreenNode? precedingMisc;
+            readonly XmlNodeSyntax.Green? body;
+            readonly GreenNode? followingMisc;
+            readonly SkippedTokensTriviaSyntax.Green? skippedTokens;
+            readonly SyntaxToken.Green? eof;
 
-            internal XmlDeclarationSyntax.Green Prologue => prologue;
-            internal GreenNode PrecedingMisc => precedingMisc;
-            internal XmlNodeSyntax.Green Body => body;
-            internal GreenNode FollowingMisc => followingMisc;
-            internal SkippedTokensTriviaSyntax.Green SkippedTokens => skippedTokens;
-            internal SyntaxToken.Green Eof => eof;
+            internal XmlDeclarationSyntax.Green? Prologue => prologue;
+            internal GreenNode? PrecedingMisc => precedingMisc;
+            internal XmlNodeSyntax.Green? Body => body;
+            internal GreenNode? FollowingMisc => followingMisc;
+            internal SkippedTokensTriviaSyntax.Green? SkippedTokens => skippedTokens;
+            internal SyntaxToken.Green? Eof => eof;
 
-            internal Green(XmlDeclarationSyntax.Green prologue, GreenNode precedingMisc, XmlNodeSyntax.Green body, GreenNode followingMisc, SkippedTokensTriviaSyntax.Green skippedTokens, SyntaxToken.Green eof)
+            internal Green(XmlDeclarationSyntax.Green? prologue, GreenNode? precedingMisc, XmlNodeSyntax.Green? body, GreenNode? followingMisc, SkippedTokensTriviaSyntax.Green? skippedTokens, SyntaxToken.Green? eof)
                 : base(SyntaxKind.XmlDocument)
             {
                 this.SlotCount = 6;
@@ -41,7 +41,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(eof);
             }
 
-            internal Green(XmlDeclarationSyntax.Green prologue, GreenNode precedingMisc, XmlNodeSyntax.Green body, GreenNode followingMisc, SkippedTokensTriviaSyntax.Green skippedTokens, SyntaxToken.Green eof, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlDeclarationSyntax.Green? prologue, GreenNode? precedingMisc, XmlNodeSyntax.Green? body, GreenNode? followingMisc, SkippedTokensTriviaSyntax.Green? skippedTokens, SyntaxToken.Green eof, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlDocument, diagnostics, annotations)
             {
                 this.SlotCount = 6;
@@ -59,9 +59,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(eof);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlDocumentSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlDocumentSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -80,7 +80,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlDocument(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(prologue, precedingMisc, body, followingMisc, skippedTokens, eof, diagnostics, GetAnnotations());
             }
@@ -93,21 +93,21 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        XmlDeclarationSyntax prologue;
-        SyntaxNode precedingMisc;
-        XmlNodeSyntax body;
-        SyntaxNode followingMisc;
-        SkippedTokensTriviaSyntax skippedTokens;
-        SyntaxToken eof;
+        XmlDeclarationSyntax? prologue;
+        SyntaxNode? precedingMisc;
+        XmlNodeSyntax? body;
+        SyntaxNode? followingMisc;
+        SkippedTokensTriviaSyntax? skippedTokens;
+        SyntaxToken? eof;
 
-        public XmlDeclarationSyntax Prologue => GetRed(ref prologue, 0);
+        public XmlDeclarationSyntax? Prologue => GetRed(ref prologue, 0);
         public SyntaxList<SyntaxNode> PrecedingMisc => new SyntaxList<SyntaxNode>(GetRed(ref precedingMisc, 1));
-        public XmlNodeSyntax Body => GetRed(ref body, 2);
+        public XmlNodeSyntax? Body => GetRed(ref body, 2);
         public SyntaxList<SyntaxNode> FollowingMisc => new SyntaxList<SyntaxNode>(GetRed(ref followingMisc, 3));
-        public SkippedTokensTriviaSyntax SkippedTokens => GetRed(ref skippedTokens, 4);
-        public SyntaxToken Eof => GetRed(ref eof, 5);
+        public SkippedTokensTriviaSyntax? SkippedTokens => GetRed(ref skippedTokens, 4);
+        public SyntaxToken? Eof => GetRed(ref eof, 5);
 
-        internal XmlDocumentSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlDocumentSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -118,7 +118,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlDocument(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -146,7 +146,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public IXmlElementSyntax RootSyntax => Body as IXmlElementSyntax;
+        public IXmlElementSyntax? RootSyntax => Body as IXmlElementSyntax;
         public IXmlElement Root => RootSyntax.AsElement;
     }
 }

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementEndTagSyntax.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly SyntaxToken.Green lessThanToken;
-            readonly XmlNameSyntax.Green name;
-            readonly SyntaxToken.Green slashGreaterThanToken;
+            readonly SyntaxToken.Green? lessThanToken;
+            readonly XmlNameSyntax.Green? name;
+            readonly SyntaxToken.Green? slashGreaterThanToken;
 
-            internal XmlNameSyntax.Green NameNode => name;
-            internal SyntaxToken.Green LessThanSlashToken => lessThanToken;
-            internal SyntaxToken.Green GreaterThanToken => slashGreaterThanToken;
+            internal XmlNameSyntax.Green? NameNode => name;
+            internal SyntaxToken.Green? LessThanSlashToken => lessThanToken;
+            internal SyntaxToken.Green? GreaterThanToken => slashGreaterThanToken;
 
-            internal Green(SyntaxToken.Green lessThanToken, XmlNameSyntax.Green name, SyntaxToken.Green slashGreaterThanToken)
+            internal Green(SyntaxToken.Green? lessThanToken, XmlNameSyntax.Green? name, SyntaxToken.Green? slashGreaterThanToken)
                 : base(SyntaxKind.XmlElementEndTag)
             {
                 this.SlotCount = 3;
@@ -28,7 +28,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal Green(SyntaxToken.Green lessThanToken, XmlNameSyntax.Green name, SyntaxToken.Green slashGreaterThanToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxToken.Green? lessThanToken, XmlNameSyntax.Green? name, SyntaxToken.Green? slashGreaterThanToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlElementEndTag, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -40,9 +40,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlElementEndTagSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlElementEndTagSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlElementEndTag(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(lessThanToken, name, slashGreaterThanToken, diagnostics, GetAnnotations());
             }
@@ -71,17 +71,17 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        PunctuationSyntax lessThanToken;
-        XmlNameSyntax nameNode;
-        PunctuationSyntax slashGreaterThanToken;
+        PunctuationSyntax? lessThanToken;
+        XmlNameSyntax? nameNode;
+        PunctuationSyntax? slashGreaterThanToken;
 
-        public PunctuationSyntax LessThanSlashToken => GetRed(ref lessThanToken, 0);
-        public XmlNameSyntax NameNode => GetRed(ref nameNode, 1);
-        public PunctuationSyntax GreaterThanToken => GetRed(ref slashGreaterThanToken, 2);
+        public PunctuationSyntax? LessThanSlashToken => GetRed(ref lessThanToken, 0);
+        public XmlNameSyntax? NameNode => GetRed(ref nameNode, 1);
+        public PunctuationSyntax? GreaterThanToken => GetRed(ref slashGreaterThanToken, 2);
 
-        public string Name => NameNode?.FullName;
+        public string? Name => NameNode?.FullName;
 
-        internal XmlElementEndTagSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlElementEndTagSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
         }
@@ -91,7 +91,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlElementEndTag(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int index)
+        internal override SyntaxNode? GetNodeSlot(int index)
         {
             switch (index)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementStartTagSyntax.cs
@@ -8,17 +8,17 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly SyntaxToken.Green lessThanToken;
-            readonly XmlNameSyntax.Green name;
-            readonly GreenNode attributes;
-            readonly SyntaxToken.Green slashGreaterThanToken;
+            readonly SyntaxToken.Green? lessThanToken;
+            readonly XmlNameSyntax.Green? name;
+            readonly GreenNode? attributes;
+            readonly SyntaxToken.Green? slashGreaterThanToken;
 
-            internal XmlNameSyntax.Green NameNode => name;
-            internal SyntaxToken.Green LessThanToken => lessThanToken;
-            internal GreenNode Attributes => attributes;
-            internal SyntaxToken.Green GreaterThanToken => slashGreaterThanToken;
+            internal XmlNameSyntax.Green? NameNode => name;
+            internal SyntaxToken.Green? LessThanToken => lessThanToken;
+            internal GreenNode? Attributes => attributes;
+            internal SyntaxToken.Green? GreaterThanToken => slashGreaterThanToken;
 
-            internal Green(SyntaxToken.Green lessThanToken, XmlNameSyntax.Green name, GreenNode attributes, SyntaxToken.Green slashGreaterThanToken)
+            internal Green(SyntaxToken.Green? lessThanToken, XmlNameSyntax.Green? name, GreenNode? attributes, SyntaxToken.Green? slashGreaterThanToken)
                 : base(SyntaxKind.XmlElementStartTag)
             {
                 this.SlotCount = 4;
@@ -32,7 +32,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal Green(SyntaxToken.Green lessThanToken, XmlNameSyntax.Green name, GreenNode attributes, SyntaxToken.Green slashGreaterThanToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(SyntaxToken.Green? lessThanToken, XmlNameSyntax.Green? name, GreenNode? attributes, SyntaxToken.Green? slashGreaterThanToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlElementStartTag, diagnostics, annotations)
             {
                 this.SlotCount = 4;
@@ -46,9 +46,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlElementStartTagSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlElementStartTagSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -65,7 +65,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlElementStartTag(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(lessThanToken, name, attributes, slashGreaterThanToken, diagnostics, GetAnnotations());
             }
@@ -78,19 +78,19 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        PunctuationSyntax lessThanToken;
-        XmlNameSyntax nameNode;
-        SyntaxNode attributesNode;
-        PunctuationSyntax greaterThanToken;
+        PunctuationSyntax? lessThanToken;
+        XmlNameSyntax? nameNode;
+        SyntaxNode? attributesNode;
+        PunctuationSyntax? greaterThanToken;
 
-        public PunctuationSyntax LessThanToken => GetRed(ref lessThanToken, 0);
-        public XmlNameSyntax NameNode => GetRed(ref nameNode, 1);
+        public PunctuationSyntax? LessThanToken => GetRed(ref lessThanToken, 0);
+        public XmlNameSyntax? NameNode => GetRed(ref nameNode, 1);
         public SyntaxList<XmlAttributeSyntax> AttributesNode => new SyntaxList<XmlAttributeSyntax>(GetRed(ref attributesNode, 2));
-        public PunctuationSyntax GreaterThanToken => GetRed(ref greaterThanToken, 3);
+        public PunctuationSyntax? GreaterThanToken => GetRed(ref greaterThanToken, 3);
 
-        public string Name => NameNode?.FullName;
+        public string? Name => NameNode?.FullName;
 
-        internal XmlElementStartTagSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlElementStartTagSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -101,7 +101,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlElementStartTag(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlElementSyntax.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#pragma warning disable CS8602
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
@@ -10,15 +13,15 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly XmlElementStartTagSyntax.Green startTag;
-            readonly GreenNode content;
-            readonly XmlElementEndTagSyntax.Green endTag;
+            readonly XmlElementStartTagSyntax.Green? startTag;
+            readonly GreenNode? content;
+            readonly XmlElementEndTagSyntax.Green? endTag;
 
-            internal XmlElementStartTagSyntax.Green StartTag => startTag;
-            internal GreenNode Content => content;
-            internal XmlElementEndTagSyntax.Green EndTag => endTag;
+            internal XmlElementStartTagSyntax.Green? StartTag => startTag;
+            internal GreenNode? Content => content;
+            internal XmlElementEndTagSyntax.Green? EndTag => endTag;
 
-            internal Green(XmlElementStartTagSyntax.Green startTag, GreenNode content, XmlElementEndTagSyntax.Green endTag)
+            internal Green(XmlElementStartTagSyntax.Green? startTag, GreenNode? content, XmlElementEndTagSyntax.Green? endTag)
                 : base(SyntaxKind.XmlElement)
             {
                 this.SlotCount = 3;
@@ -30,7 +33,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endTag);
             }
 
-            internal Green(XmlElementStartTagSyntax.Green startTag, GreenNode content, XmlElementEndTagSyntax.Green endTag, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlElementStartTagSyntax.Green? startTag, GreenNode? content, XmlElementEndTagSyntax.Green? endTag, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlElement, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -42,9 +45,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endTag);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlElementSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlElementSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -60,7 +63,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlElement(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(startTag, content, endTag, diagnostics, GetAnnotations());
             }
@@ -73,15 +76,15 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        XmlElementStartTagSyntax startTag;
-        SyntaxNode content;
-        XmlElementEndTagSyntax endTag;
+        XmlElementStartTagSyntax? startTag;
+        SyntaxNode? content;
+        XmlElementEndTagSyntax? endTag;
 
-        public XmlElementStartTagSyntax StartTag => GetRed(ref startTag, 0);
+        public XmlElementStartTagSyntax? StartTag => GetRed(ref startTag, 0);
         public SyntaxList<SyntaxNode> Content => new SyntaxList<SyntaxNode>(GetRed(ref content, 1));
-        public XmlElementEndTagSyntax EndTag => GetRed(ref endTag, 2);
+        public XmlElementEndTagSyntax? EndTag => GetRed(ref endTag, 2);
 
-        internal XmlElementSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlElementSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -92,7 +95,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlElement(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -103,7 +106,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -114,8 +117,8 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlNameSyntax NameNode => StartTag?.NameNode;
-        public string Name => StartTag?.Name;
+        public XmlNameSyntax? NameNode => StartTag?.NameNode;
+        public string? Name => StartTag?.Name;
 
         public IEnumerable<IXmlElementSyntax> Elements
         {
@@ -134,11 +137,11 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlAttributeSyntax GetAttribute(string localName, string prefix = null) => StartTag.AttributesNode.FirstOrDefault(
+        public XmlAttributeSyntax? GetAttribute(string localName, string? prefix = null) => StartTag.AttributesNode.FirstOrDefault(
             attr => string.Equals(attr.NameNode.LocalName, localName, StringComparison.Ordinal) && string.Equals(attr.NameNode.Prefix, prefix, StringComparison.Ordinal)
         );
 
-        public string GetAttributeValue(string localName, string prefix = null) => GetAttribute(localName, prefix)?.Value;
+        public string? GetAttributeValue(string localName, string? prefix = null) => GetAttribute(localName, prefix)?.Value;
 
         public IXmlElement AsElement => this;
         public IXmlElementSyntax AsSyntaxElement => this;
@@ -148,11 +151,11 @@ namespace Microsoft.Language.Xml
 
         int IXmlElement.FullWidth => FullWidth;
 
-        string IXmlElement.Name => Name;
+        string? IXmlElement.Name => Name;
 
         string IXmlElement.Value => Content.ToFullString();
 
-        IXmlElement IXmlElement.Parent => Parent as IXmlElement;
+        IXmlElement? IXmlElement.Parent => Parent as IXmlElement;
 
         IEnumerable<IXmlElement> IXmlElement.Elements => Elements.Select(el => el.AsElement);
 
@@ -181,13 +184,13 @@ namespace Microsoft.Language.Xml
 
         IXmlElementSyntax IXmlElement.AsSyntaxElement => this;
 
-        string IXmlElement.this[string attributeName] => GetAttributeValue(attributeName);
+        string? IXmlElement.this[string attributeName] => GetAttributeValue(attributeName);
         #endregion
 
         #region IXmlElementSyntax
 
-        IEnumerable<XmlAttributeSyntax> IXmlElementSyntax.Attributes => (IEnumerable<XmlAttributeSyntax>)StartTag?.AttributesNode;
-        IXmlElementSyntax IXmlElementSyntax.Parent => ParentElement;
+        IEnumerable<XmlAttributeSyntax>? IXmlElementSyntax.Attributes => (IEnumerable<XmlAttributeSyntax>?)StartTag?.AttributesNode;
+        IXmlElementSyntax? IXmlElementSyntax.Parent => ParentElement;
         XmlNodeSyntax IXmlElementSyntax.AsNode => this;
         SyntaxList<XmlAttributeSyntax> IXmlElementSyntax.AttributesNode => StartTag.AttributesNode;
 

--- a/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEmptyElementSyntax.cs
@@ -2,6 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#pragma warning disable CS8602
+
+#pragma warning disable CS8604
+
 namespace Microsoft.Language.Xml
 {
     using InternalSyntax;
@@ -10,17 +14,17 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green lessThanToken;
-            readonly XmlNameSyntax.Green name;
-            readonly GreenNode attributes;
-            readonly PunctuationSyntax.Green slashGreaterThanToken;
+            readonly PunctuationSyntax.Green? lessThanToken;
+            readonly XmlNameSyntax.Green? name;
+            readonly GreenNode? attributes;
+            readonly PunctuationSyntax.Green? slashGreaterThanToken;
 
-            internal PunctuationSyntax.Green LessThanToken => lessThanToken;
-            internal XmlNameSyntax.Green NameNode => name;
-            internal GreenNode AttributesNode => attributes;
-            internal PunctuationSyntax.Green SlashGreaterThanToken => slashGreaterThanToken;
+            internal PunctuationSyntax.Green? LessThanToken => lessThanToken;
+            internal XmlNameSyntax.Green? NameNode => name;
+            internal GreenNode? AttributesNode => attributes;
+            internal PunctuationSyntax.Green? SlashGreaterThanToken => slashGreaterThanToken;
 
-            internal Green(PunctuationSyntax.Green lessThanToken, XmlNameSyntax.Green name, GreenNode attributes, PunctuationSyntax.Green slashGreaterThanToken)
+            internal Green(PunctuationSyntax.Green? lessThanToken, XmlNameSyntax.Green? name, GreenNode? attributes, PunctuationSyntax.Green? slashGreaterThanToken)
                 : base(SyntaxKind.XmlEmptyElement)
             {
                 this.SlotCount = 4;
@@ -34,7 +38,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal Green(PunctuationSyntax.Green lessThanToken, XmlNameSyntax.Green name, GreenNode attributes, PunctuationSyntax.Green slashGreaterThanToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(PunctuationSyntax.Green? lessThanToken, XmlNameSyntax.Green? name, GreenNode? attributes, PunctuationSyntax.Green? slashGreaterThanToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlEmptyElement, diagnostics, annotations)
             {
                 this.SlotCount = 4;
@@ -48,9 +52,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(slashGreaterThanToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlEmptyElementSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlEmptyElementSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -67,7 +71,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlEmptyElement(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(lessThanToken, name, attributes, slashGreaterThanToken, diagnostics, GetAnnotations());
             }
@@ -78,17 +82,17 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        PunctuationSyntax lessThanToken;
-        XmlNameSyntax nameNode;
-        SyntaxNode attributesNode;
-        PunctuationSyntax slashGreaterThanToken;
+        PunctuationSyntax? lessThanToken;
+        XmlNameSyntax? nameNode;
+        SyntaxNode? attributesNode;
+        PunctuationSyntax? slashGreaterThanToken;
 
-        public PunctuationSyntax LessThanToken => GetRed(ref lessThanToken, 0);
-        public XmlNameSyntax NameNode => GetRed(ref nameNode, 1);
+        public PunctuationSyntax? LessThanToken => GetRed(ref lessThanToken, 0);
+        public XmlNameSyntax? NameNode => GetRed(ref nameNode, 1);
         public SyntaxList<XmlAttributeSyntax> AttributesNode => new SyntaxList<XmlAttributeSyntax>(GetRed(ref attributesNode, 2));
-        public PunctuationSyntax SlashGreaterThanToken => GetRed(ref slashGreaterThanToken, 3);
+        public PunctuationSyntax? SlashGreaterThanToken => GetRed(ref slashGreaterThanToken, 3);
 
-        internal XmlEmptyElementSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlEmptyElementSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -99,7 +103,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlEmptyElement(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -111,7 +115,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -123,7 +127,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public string Name => NameNode?.FullName;
+        public string? Name => NameNode?.FullName;
 
         public SyntaxList<SyntaxNode> Content => default(SyntaxList<SyntaxNode>);
 
@@ -135,11 +139,11 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlAttributeSyntax GetAttribute(string localName, string prefix = null) => AttributesNode.FirstOrDefault(
+        public XmlAttributeSyntax? GetAttribute(string localName, string? prefix = null) => AttributesNode.FirstOrDefault(
             attr => string.Equals(attr.NameNode.LocalName, localName, StringComparison.Ordinal) && string.Equals(attr.NameNode.Prefix, prefix, StringComparison.Ordinal)
         );
 
-        public string GetAttributeValue(string localName, string prefix = null) => GetAttribute(localName, prefix)?.Value;
+        public string? GetAttributeValue(string localName, string? prefix = null) => GetAttribute(localName, prefix)?.Value;
 
         public IXmlElement AsElement => this;
         public IXmlElementSyntax AsSyntaxElement => this;
@@ -149,11 +153,11 @@ namespace Microsoft.Language.Xml
 
         int IXmlElement.FullWidth => FullWidth;
 
-        string IXmlElement.Name => Name;
+        string? IXmlElement.Name => Name;
 
         string IXmlElement.Value => Content.ToFullString();
 
-        IXmlElement IXmlElement.Parent => Parent as IXmlElement;
+        IXmlElement? IXmlElement.Parent => Parent as IXmlElement;
 
         IEnumerable<IXmlElement> IXmlElement.Elements => Elements.Select(el => el.AsElement);
 
@@ -182,13 +186,13 @@ namespace Microsoft.Language.Xml
 
         IXmlElementSyntax IXmlElement.AsSyntaxElement => this;
 
-        string IXmlElement.this[string attributeName] => GetAttributeValue(attributeName);
+        string? IXmlElement.this[string attributeName] => GetAttributeValue(attributeName);
         #endregion
 
         #region IXmlElementSyntax
 
         IEnumerable<XmlAttributeSyntax> IXmlElementSyntax.Attributes => (IEnumerable<XmlAttributeSyntax>)AttributesNode;
-        IXmlElementSyntax IXmlElementSyntax.Parent => ParentElement;
+        IXmlElementSyntax? IXmlElementSyntax.Parent => ParentElement;
         XmlNodeSyntax IXmlElementSyntax.AsNode => this;
 
         IXmlElementSyntax IXmlElementSyntax.WithName(XmlNameSyntax newName) => WithName(newName);

--- a/src/Microsoft.Language.Xml/Syntax/XmlEntityTokenSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlEntityTokenSyntax.cs
@@ -8,19 +8,19 @@ namespace Microsoft.Language.Xml
         {
             public string Value { get; }
 
-            internal Green(string text, string value, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(string text, string value, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(SyntaxKind.XmlEntityLiteralToken, text, leadingTrivia, trailingTrivia)
             {
                 Value = value;
             }
 
-            internal Green(string text, string value, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(string text, string value, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlEntityLiteralToken, text, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
                 Value = value;
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlEntityTokenSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlEntityTokenSyntax(this, parent, position);
         }
 
         internal new Green GreenNode => (Green)base.GreenNode;
@@ -28,18 +28,18 @@ namespace Microsoft.Language.Xml
         public string Entity => Text;
         public string EntityValue => GreenNode.Value;
 
-        internal XmlEntityTokenSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlEntityTokenSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlEntityTokenSyntax)new Green(Entity, EntityValue, trivia?.GreenNode, GetTrailingTrivia().Node?.GreenNode).CreateRed(Parent, Start);
         }
 
-        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlEntityTokenSyntax)new Green(Entity, EntityValue, GetLeadingTrivia().Node?.GreenNode, trivia?.GreenNode).CreateRed(Parent, Start);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlNameSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlNameSyntax.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly XmlPrefixSyntax.Green xmlPrefix;
-            readonly XmlNameTokenSyntax.Green localName;
+            readonly XmlPrefixSyntax.Green? xmlPrefix;
+            readonly XmlNameTokenSyntax.Green? localName;
 
-            internal XmlPrefixSyntax.Green Prefix => xmlPrefix;
-            internal XmlNameTokenSyntax.Green LocalName => localName;
+            internal XmlPrefixSyntax.Green? Prefix => xmlPrefix;
+            internal XmlNameTokenSyntax.Green? LocalName => localName;
 
-            internal Green(XmlPrefixSyntax.Green xmlPrefix, XmlNameTokenSyntax.Green localName)
+            internal Green(XmlPrefixSyntax.Green? xmlPrefix, XmlNameTokenSyntax.Green? localName)
                 : base(SyntaxKind.XmlName)
             {
                 this.SlotCount = 2;
@@ -24,7 +24,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(localName);
             }
 
-            internal Green(XmlPrefixSyntax.Green xmlPrefix, XmlNameTokenSyntax.Green localName, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlPrefixSyntax.Green? xmlPrefix, XmlNameTokenSyntax.Green? localName, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlName, diagnostics, annotations)
             {
                 this.SlotCount = 2;
@@ -34,9 +34,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(localName);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlNameSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlNameSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -52,7 +52,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlName(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(xmlPrefix, localName, diagnostics, GetAnnotations());
             }
@@ -65,13 +65,13 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        XmlPrefixSyntax prefix;
-        XmlNameTokenSyntax localName;
+        XmlPrefixSyntax? prefix;
+        XmlNameTokenSyntax? localName;
 
-        public XmlPrefixSyntax PrefixNode => GetRed(ref prefix, 0);
-        public XmlNameTokenSyntax LocalNameNode => GetRed(ref localName, 1);
+        public XmlPrefixSyntax? PrefixNode => GetRed(ref prefix, 0);
+        public XmlNameTokenSyntax? LocalNameNode => GetRed(ref localName, 1);
 
-        internal XmlNameSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlNameSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -82,8 +82,8 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlName(this);
         }
 
-        public string LocalName => LocalNameNode?.Text;
-        public string Prefix => PrefixNode?.Name?.Text;
+        public string? LocalName => LocalNameNode?.Text;
+        public string? Prefix => PrefixNode?.Name?.Text;
 
         public string FullName => (PrefixNode != null ? (PrefixNode.Name?.Text ?? string.Empty) + ":" : string.Empty) + (LocalNameNode?.Text ?? string.Empty);
 
@@ -92,7 +92,7 @@ namespace Microsoft.Language.Xml
             return $"XmlNameSyntax {FullName}";
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -112,7 +112,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlNameSyntax Update(XmlPrefixSyntax prefix, XmlNameTokenSyntax localName)
+        public XmlNameSyntax Update(XmlPrefixSyntax? prefix, XmlNameTokenSyntax? localName)
         {
             if (prefix != this.PrefixNode || localName != this.LocalNameNode)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlNameTokenSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlNameTokenSyntax.cs
@@ -8,29 +8,29 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : SyntaxToken.Green
         {
-            internal Green(string name, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(SyntaxKind.XmlNameToken, name, leadingTrivia, trailingTrivia)
             {
             }
 
-            internal Green(string name, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlNameToken, name, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlNameTokenSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlNameTokenSyntax(this, parent, position);
 
-            public override SyntaxToken.Green WithLeadingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithLeadingTrivia(GreenNode? trivia)
             {
                 return new Green(Text, trivia, TrailingTrivia);
             }
 
-            public override SyntaxToken.Green WithTrailingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithTrailingTrivia(GreenNode? trivia)
             {
                 return new Green(Text, LeadingTrivia, trivia);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(Text, LeadingTrivia, TrailingTrivia, diagnostics, GetAnnotations());
             }
@@ -45,18 +45,18 @@ namespace Microsoft.Language.Xml
 
         public string Name => Text;
 
-        internal XmlNameTokenSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlNameTokenSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlNameTokenSyntax)new Green(Text, trivia?.GreenNode, GetTrailingTrivia().Node?.GreenNode).CreateRed(Parent, Start);
         }
 
-        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlNameTokenSyntax)new Green(Text, GetLeadingTrivia().Node?.GreenNode, trivia?.GreenNode).CreateRed(Parent, Start);
         }

--- a/src/Microsoft.Language.Xml/Syntax/XmlNodeSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlNodeSyntax.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Language.Xml
             {
             }
 
-            protected Green(SyntaxKind kind, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            protected Green(SyntaxKind kind, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(kind, diagnostics, annotations)
             {
             }
@@ -30,7 +30,7 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        internal XmlNodeSyntax(Green green, SyntaxNode parent, int position) : base(green, parent, position)
+        internal XmlNodeSyntax(Green green, SyntaxNode? parent, int position) : base(green, parent, position)
         {
         }
 

--- a/src/Microsoft.Language.Xml/Syntax/XmlPrefixSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlPrefixSyntax.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Language.Xml
     {
         internal class Green : GreenNode
         {
-            readonly XmlNameTokenSyntax.Green name;
-            readonly PunctuationSyntax.Green colonToken;
+            readonly XmlNameTokenSyntax.Green? name;
+            readonly PunctuationSyntax.Green? colonToken;
 
-            internal XmlNameTokenSyntax.Green Name => name;
+            internal XmlNameTokenSyntax.Green? Name => name;
 
-            internal Green(XmlNameTokenSyntax.Green name, PunctuationSyntax.Green colonToken)
+            internal Green(XmlNameTokenSyntax.Green? name, PunctuationSyntax.Green? colonToken)
                 : base(SyntaxKind.XmlPrefix)
             {
                 this.SlotCount = 2;
@@ -23,7 +23,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(colonToken);
             }
 
-            internal Green(XmlNameTokenSyntax.Green name, PunctuationSyntax.Green colonToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(XmlNameTokenSyntax.Green? name, PunctuationSyntax.Green? colonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlPrefix, diagnostics, annotations)
             {
                 this.SlotCount = 2;
@@ -33,9 +33,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(colonToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlPrefixSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlPrefixSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -51,7 +51,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlPrefix(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(name, colonToken, diagnostics, GetAnnotations());
             }
@@ -64,13 +64,13 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        XmlNameTokenSyntax name;
-        PunctuationSyntax colonToken;
+        XmlNameTokenSyntax? name;
+        PunctuationSyntax? colonToken;
 
-        public XmlNameTokenSyntax Name => GetRed(ref name, 0);
-        public PunctuationSyntax ColonToken => GetRed(ref colonToken, 1);
+        public XmlNameTokenSyntax? Name => GetRed(ref name, 0);
+        public PunctuationSyntax? ColonToken => GetRed(ref colonToken, 1);
 
-        internal XmlPrefixSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlPrefixSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlPrefix(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -100,7 +100,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlPrefixSyntax Update(XmlNameTokenSyntax name, PunctuationSyntax colonToken)
+        public XmlPrefixSyntax Update(XmlNameTokenSyntax? name, PunctuationSyntax? colonToken)
         {
             if (name != this.Name || colonToken != this.ColonToken)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlProcessingInstructionSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlProcessingInstructionSyntax.cs
@@ -11,20 +11,20 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green lessThanQuestionToken;
-            readonly XmlNameTokenSyntax.Green name;
-            readonly GreenNode textTokens;
-            readonly PunctuationSyntax.Green questionGreaterThanToken;
+            readonly PunctuationSyntax.Green? lessThanQuestionToken;
+            readonly XmlNameTokenSyntax.Green? name;
+            readonly GreenNode? textTokens;
+            readonly PunctuationSyntax.Green? questionGreaterThanToken;
 
-            internal PunctuationSyntax.Green LessThanQuestionToken => lessThanQuestionToken;
-            internal XmlNameTokenSyntax.Green Name => name;
+            internal PunctuationSyntax.Green? LessThanQuestionToken => lessThanQuestionToken;
+            internal XmlNameTokenSyntax.Green? Name => name;
             internal InternalSyntax.SyntaxList<GreenNode> TextTokens => textTokens;
-            internal PunctuationSyntax.Green QuestionGreaterThanToken => questionGreaterThanToken;
+            internal PunctuationSyntax.Green? QuestionGreaterThanToken => questionGreaterThanToken;
 
-            internal Green(PunctuationSyntax.Green lessThanQuestionToken,
-                           XmlNameTokenSyntax.Green name,
-                           GreenNode textTokens,
-                           PunctuationSyntax.Green questionGreaterThanToken)
+            internal Green(PunctuationSyntax.Green? lessThanQuestionToken,
+                           XmlNameTokenSyntax.Green? name,
+                           GreenNode? textTokens,
+                           PunctuationSyntax.Green? questionGreaterThanToken)
                 : base(SyntaxKind.XmlProcessingInstruction)
             {
                 this.SlotCount = 4;
@@ -38,11 +38,11 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(questionGreaterThanToken);
             }
 
-            internal Green(PunctuationSyntax.Green lessThanQuestionToken,
-                            XmlNameTokenSyntax.Green name,
-                            GreenNode textTokens,
-                            PunctuationSyntax.Green questionGreaterThanToken,
-                            DiagnosticInfo[] diagnostics,
+            internal Green(PunctuationSyntax.Green? lessThanQuestionToken,
+                            XmlNameTokenSyntax.Green? name,
+                            GreenNode? textTokens,
+                            PunctuationSyntax.Green? questionGreaterThanToken,
+                            DiagnosticInfo[]? diagnostics,
                             SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlProcessingInstruction, diagnostics, annotations)
             {
@@ -57,9 +57,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(questionGreaterThanToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlProcessingInstructionSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlProcessingInstructionSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlProcessingInstruction(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(lessThanQuestionToken, name, textTokens, questionGreaterThanToken, diagnostics, GetAnnotations());
             }
@@ -89,17 +89,17 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        PunctuationSyntax lessThanQuestionToken;
-        XmlNameTokenSyntax name;
-        SyntaxNode textTokens;
-        PunctuationSyntax questionGreaterThanToken;
+        PunctuationSyntax? lessThanQuestionToken;
+        XmlNameTokenSyntax? name;
+        SyntaxNode? textTokens;
+        PunctuationSyntax? questionGreaterThanToken;
 
-        public PunctuationSyntax LessThanQuestionToken => GetRed(ref lessThanQuestionToken, 0);
-        public XmlNameTokenSyntax Name => GetRed(ref name, 1);
+        public PunctuationSyntax? LessThanQuestionToken => GetRed(ref lessThanQuestionToken, 0);
+        public XmlNameTokenSyntax? Name => GetRed(ref name, 1);
         public SyntaxList<SyntaxNode> TextTokens => new SyntaxList<SyntaxNode>(GetRed(ref textTokens, 2));
-        public PunctuationSyntax QuestionGreaterThanToken => GetRed(ref questionGreaterThanToken, 3);
+        public PunctuationSyntax? QuestionGreaterThanToken => GetRed(ref questionGreaterThanToken, 3);
 
-        internal XmlProcessingInstructionSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlProcessingInstructionSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -110,7 +110,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlProcessingInstruction(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -122,7 +122,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlStringSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlStringSyntax.cs
@@ -8,17 +8,17 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly PunctuationSyntax.Green startQuoteToken;
-            readonly GreenNode value;
-            readonly PunctuationSyntax.Green endQuoteToken;
+            readonly PunctuationSyntax.Green? startQuoteToken;
+            readonly GreenNode? value;
+            readonly PunctuationSyntax.Green? endQuoteToken;
 
-            internal PunctuationSyntax.Green StartQuoteToken => startQuoteToken;
-            internal GreenNode ValueNode => value;
-            internal PunctuationSyntax.Green EndQuoteToken => endQuoteToken;
+            internal PunctuationSyntax.Green? StartQuoteToken => startQuoteToken;
+            internal GreenNode? ValueNode => value;
+            internal PunctuationSyntax.Green? EndQuoteToken => endQuoteToken;
 
             internal InternalSyntax.SyntaxList<GreenNode> TextTokens => new InternalSyntax.SyntaxList<GreenNode>(value);
 
-            internal Green(PunctuationSyntax.Green startQuoteToken, GreenNode value, PunctuationSyntax.Green endQuoteToken)
+            internal Green(PunctuationSyntax.Green? startQuoteToken, GreenNode? value, PunctuationSyntax.Green? endQuoteToken)
                 : base(SyntaxKind.XmlString)
             {
                 this.SlotCount = 3;
@@ -30,7 +30,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endQuoteToken);
             }
 
-            internal Green(PunctuationSyntax.Green startQuoteToken, GreenNode value, PunctuationSyntax.Green endQuoteToken, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(PunctuationSyntax.Green? startQuoteToken, GreenNode? value, PunctuationSyntax.Green? endQuoteToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlString, diagnostics, annotations)
             {
                 this.SlotCount = 3;
@@ -42,9 +42,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(endQuoteToken);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlStringSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlStringSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -60,7 +60,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlString(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(startQuoteToken, value, endQuoteToken, diagnostics, GetAnnotations());
             }
@@ -73,15 +73,15 @@ namespace Microsoft.Language.Xml
 
         internal new Green GreenNode => (Green)base.GreenNode;
 
-        PunctuationSyntax startQuoteToken;
-        SyntaxNode textTokens;
-        PunctuationSyntax endQuoteToken;
+        PunctuationSyntax? startQuoteToken;
+        SyntaxNode? textTokens;
+        PunctuationSyntax? endQuoteToken;
 
-        public PunctuationSyntax StartQuoteToken => GetRed(ref startQuoteToken, 0);
+        public PunctuationSyntax? StartQuoteToken => GetRed(ref startQuoteToken, 0);
         public SyntaxList<SyntaxNode> TextTokens => new SyntaxList<SyntaxNode>(GetRed(ref textTokens, 1));
-        public PunctuationSyntax EndQuoteToken => GetRed(ref endQuoteToken, 2);
+        public PunctuationSyntax? EndQuoteToken => GetRed(ref endQuoteToken, 2);
 
-        internal XmlStringSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlStringSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -92,7 +92,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlString(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {
@@ -114,7 +114,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public XmlStringSyntax Update(PunctuationSyntax startQuoteToken, SyntaxList<SyntaxNode> textTokens, PunctuationSyntax endQuoteToken)
+        public XmlStringSyntax Update(PunctuationSyntax? startQuoteToken, SyntaxList<SyntaxNode> textTokens, PunctuationSyntax? endQuoteToken)
         {
             if (startQuoteToken != this.StartQuoteToken || textTokens != this.TextTokens || endQuoteToken != this.EndQuoteToken)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlTextSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlTextSyntax.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : XmlNodeSyntax.Green
         {
-            readonly GreenNode value;
+            readonly GreenNode? value;
 
             internal InternalSyntax.SyntaxList<GreenNode> TextTokens => new InternalSyntax.SyntaxList<GreenNode>(value);
 
-            internal Green(GreenNode value)
+            internal Green(GreenNode? value)
                 : base(SyntaxKind.XmlText)
             {
                 this.SlotCount = 1;
@@ -20,7 +20,7 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(value);
             }
 
-            internal Green(GreenNode value, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            internal Green(GreenNode? value, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(SyntaxKind.XmlText, diagnostics, annotations)
             {
                 this.SlotCount = 1;
@@ -28,9 +28,9 @@ namespace Microsoft.Language.Xml
                 AdjustWidth(value);
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlTextSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlTextSyntax(this, parent, position);
 
-            internal override GreenNode GetSlot(int index)
+            internal override GreenNode? GetSlot(int index)
             {
                 switch (index)
                 {
@@ -44,7 +44,7 @@ namespace Microsoft.Language.Xml
                 return visitor.VisitXmlText(this);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(value, diagnostics, GetAnnotations());
             }
@@ -55,11 +55,11 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        SyntaxNode textTokens;
+        SyntaxNode? textTokens;
 
         public SyntaxList<SyntaxNode> TextTokens => new SyntaxList<SyntaxNode>(GetRed(ref textTokens, 0));
 
-        internal XmlTextSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlTextSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
@@ -72,7 +72,7 @@ namespace Microsoft.Language.Xml
             return visitor.VisitXmlText(this);
         }
 
-        internal override SyntaxNode GetCachedSlot(int index)
+        internal override SyntaxNode? GetCachedSlot(int index)
         {
             switch (index)
             {
@@ -81,7 +81,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        internal override SyntaxNode GetNodeSlot(int slot)
+        internal override SyntaxNode? GetNodeSlot(int slot)
         {
             switch (slot)
             {

--- a/src/Microsoft.Language.Xml/Syntax/XmlTextTokenSyntax.cs
+++ b/src/Microsoft.Language.Xml/Syntax/XmlTextTokenSyntax.cs
@@ -6,34 +6,34 @@ namespace Microsoft.Language.Xml
     {
         internal new class Green : SyntaxToken.Green
         {
-            internal Green(string text, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            internal Green(string text, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(SyntaxKind.XmlTextLiteralToken, text, leadingTrivia, trailingTrivia)
             {
             }
 
-            protected Green(SyntaxKind kind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia)
+            protected Green(SyntaxKind kind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia)
                 : base(kind, name, leadingTrivia, trailingTrivia)
             {
             }
 
-            protected Green(SyntaxKind kind, string name, GreenNode leadingTrivia, GreenNode trailingTrivia, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations)
+            protected Green(SyntaxKind kind, string name, GreenNode? leadingTrivia, GreenNode? trailingTrivia, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[] annotations)
                 : base(kind, name, leadingTrivia, trailingTrivia, diagnostics, annotations)
             {
             }
 
-            internal override SyntaxNode CreateRed(SyntaxNode parent, int position) => new XmlTextTokenSyntax(this, parent, position);
+            internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new XmlTextTokenSyntax(this, parent, position);
 
-            public override SyntaxToken.Green WithLeadingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithLeadingTrivia(GreenNode? trivia)
             {
                 return new Green(Kind, Text, trivia, TrailingTrivia);
             }
 
-            public override SyntaxToken.Green WithTrailingTrivia(GreenNode trivia)
+            public override SyntaxToken.Green WithTrailingTrivia(GreenNode? trivia)
             {
                 return new Green(Kind, Text, LeadingTrivia, trivia);
             }
 
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
             {
                 return new Green(Kind, Text, LeadingTrivia, TrailingTrivia, diagnostics, GetAnnotations());
             }
@@ -46,18 +46,18 @@ namespace Microsoft.Language.Xml
 
         public string Value => Text;
 
-        internal XmlTextTokenSyntax(Green green, SyntaxNode parent, int position)
+        internal XmlTextTokenSyntax(Green green, SyntaxNode? parent, int position)
             : base(green, parent, position)
         {
 
         }
 
-        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithLeadingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlTextTokenSyntax)new Green(Text, trivia?.GreenNode, GetTrailingTrivia().Node?.GreenNode).CreateRed(Parent, Start);
         }
 
-        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode trivia)
+        internal override SyntaxToken WithTrailingTriviaCore(SyntaxNode? trivia)
         {
             return (XmlTextTokenSyntax)new Green(Text, GetLeadingTrivia().Node?.GreenNode, trivia?.GreenNode).CreateRed(Parent, Start);
         }

--- a/src/Microsoft.Language.Xml/TextChange.cs
+++ b/src/Microsoft.Language.Xml/TextChange.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Language.Xml
             return string.Format("{0}: {{ {1}, \"{2}\" }}", this.GetType().Name, Span, NewText);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TextChange && this.Equals((TextChange)obj);
         }

--- a/src/Microsoft.Language.Xml/TextChangeRange.cs
+++ b/src/Microsoft.Language.Xml/TextChangeRange.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Language.Xml
         /// <summary>
         /// Compares current instance of <see cref="TextChangeRange"/> to another.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TextChangeRange && Equals((TextChangeRange)obj);
         }

--- a/src/Microsoft.Language.Xml/TextSpan.cs
+++ b/src/Microsoft.Language.Xml/TextSpan.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Language.Xml
         /// <summary>
         /// Determines if current instance of <see cref="TextSpan"/> is equal to another.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TextSpan && Equals((TextSpan)obj);
         }

--- a/src/Microsoft.Language.Xml/Utilities/ArrayBuilder.cs
+++ b/src/Microsoft.Language.Xml/Utilities/ArrayBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Language.Xml
 
         private readonly ImmutableArray<T>.Builder _builder;
 
-        private readonly ObjectPool<ArrayBuilder<T>> _pool;
+        private readonly ObjectPool<ArrayBuilder<T>>? _pool;
 
         public ArrayBuilder (int size)
         {
@@ -90,7 +90,7 @@ namespace Microsoft.Language.Xml
         public void SetItem (int index, T value)
         {
             while (index > _builder.Count) {
-                _builder.Add (default);
+                _builder.Add (default!);
             }
 
             if (index == _builder.Count) {
@@ -242,7 +242,7 @@ namespace Microsoft.Language.Xml
 
             var tmp = ArrayBuilder<U>.GetInstance (Count);
             foreach (var i in this) {
-                tmp.Add ((U)i);
+                tmp.Add ((U)i!);
             }
 
             return tmp.ToImmutableAndFree ();
@@ -337,8 +337,8 @@ namespace Microsoft.Language.Xml
 
         public static ObjectPool<ArrayBuilder<T>> CreatePool (int size)
         {
-            ObjectPool<ArrayBuilder<T>> pool = null;
-            pool = new ObjectPool<ArrayBuilder<T>> (() => new ArrayBuilder<T> (pool), size);
+            ObjectPool<ArrayBuilder<T>>? pool = null;
+            pool = new ObjectPool<ArrayBuilder<T>> (() => new ArrayBuilder<T> (pool!), size);
             return pool;
         }
 
@@ -359,7 +359,8 @@ namespace Microsoft.Language.Xml
             return GetEnumerator ();
         }
 
-        internal Dictionary<K, ImmutableArray<T>> ToDictionary<K> (Func<T, K> keySelector, IEqualityComparer<K> comparer = null)
+        internal Dictionary<K, ImmutableArray<T>> ToDictionary<K> (Func<T, K> keySelector, IEqualityComparer<K>? comparer = null)
+            where K : notnull
         {
             if (this.Count == 1) {
                 var dictionary1 = new Dictionary<K, ImmutableArray<T>> (1, comparer);
@@ -524,7 +525,7 @@ namespace Microsoft.Language.Xml
             {
             }
 
-            object System.Collections.IEnumerator.Current {
+            object? System.Collections.IEnumerator.Current {
                 get {
                     return this.Current;
                 }

--- a/src/Microsoft.Language.Xml/Utilities/ArrayElement.cs
+++ b/src/Microsoft.Language.Xml/Utilities/ArrayElement.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Language.Xml
         // as JIT does not know if the write goes to a stack or a heap location.
         // Assigning to Value directly easily avoids all this redundancy.
 
-        public static ArrayElement<T>[] MakeElementArray(T[] items)
+        public static ArrayElement<T>[]? MakeElementArray(T[] items)
         {
             if (items == null)
             {
@@ -42,14 +42,14 @@ namespace Microsoft.Language.Xml
             return array;
         }
 
-        public static T[] MakeArray(ArrayElement<T>[] items)
+        public static T?[]? MakeArray(ArrayElement<T>[] items)
         {
             if (items == null)
             {
                 return null;
             }
 
-            var array = new T[items.Length];
+            var array = new T?[items.Length];
             for (int i = 0; i < items.Length; i++)
             {
                 array[i] = items[i].Value;

--- a/src/Microsoft.Language.Xml/Utilities/FirstTokenReplacer.cs
+++ b/src/Microsoft.Language.Xml/Utilities/FirstTokenReplacer.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Microsoft.Language.Xml
 {
+    using System.Diagnostics.CodeAnalysis;
     using InternalSyntax;
 
     internal class FirstTokenReplacer : InternalSyntax.SyntaxRewriter
@@ -19,7 +20,8 @@ namespace Microsoft.Language.Xml
             return ((TTree)new FirstTokenReplacer(newItem).Visit(root));
         }
 
-        public override SyntaxToken.Green VisitSyntaxToken(SyntaxToken.Green token)
+        [return: NotNullIfNotNull(nameof(token))]
+        public override SyntaxToken.Green? VisitSyntaxToken(SyntaxToken.Green? token)
         {
             if (token == null)
             {

--- a/src/Microsoft.Language.Xml/Utilities/LastTokenReplacer.cs
+++ b/src/Microsoft.Language.Xml/Utilities/LastTokenReplacer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Language.Xml
             return (TTree)new LastTokenReplacer(newItem).Visit(root);
         }
 
-        public override GreenNode Visit(GreenNode node)
+        public override GreenNode? Visit(GreenNode? node)
         {
             if (node == null)
             {
@@ -61,7 +61,7 @@ namespace Microsoft.Language.Xml
 
                 var prevIdx = _skipCnt;
                 _skipCnt = allChildrenCnt - 1;
-                GreenNode result;
+                GreenNode? result;
                 if (node.IsList)
                 {
                     result = VisitList<GreenNode>(new InternalSyntax.SyntaxList<GreenNode>(node)).Node;
@@ -80,7 +80,7 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        public override SyntaxToken.Green VisitSyntaxToken(SyntaxToken.Green token)
+        public override SyntaxToken.Green VisitSyntaxToken(SyntaxToken.Green? token)
         {
             return _newItem(token);
         }

--- a/src/Microsoft.Language.Xml/Utilities/ObjectPool.cs
+++ b/src/Microsoft.Language.Xml/Utilities/ObjectPool.cs
@@ -17,6 +17,8 @@ using System.Runtime.CompilerServices;
 
 #endif
 
+#pragma warning disable CS8601
+
 namespace Microsoft.Language.Xml
 {
     /// <summary>
@@ -198,7 +200,7 @@ namespace Microsoft.Language.Xml
         /// return a larger array to the pool than was originally allocated.
         /// </summary>
         [Conditional("DEBUG")]
-        internal void ForgetTrackedObject(T old, T replacement = null)
+        internal void ForgetTrackedObject(T old, T? replacement = null)
         {
 #if DETECT_LEAKS
             LeakTracker tracker;

--- a/src/Microsoft.Language.Xml/Utilities/StringTable.cs
+++ b/src/Microsoft.Language.Xml/Utilities/StringTable.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     /// <summary>
@@ -75,17 +77,17 @@ namespace Microsoft.Language.Xml
         // implement Poolable object pattern
         #region "Poolable"
 
-        private StringTable(ObjectPool<StringTable> pool)
+        private StringTable(ObjectPool<StringTable>? pool)
         {
             this.pool = pool;
         }
 
-        private readonly ObjectPool<StringTable> pool;
+        private readonly ObjectPool<StringTable>? pool;
         private static readonly ObjectPool<StringTable> StaticPool = CreatePool();
 
         private static ObjectPool<StringTable> CreatePool()
         {
-            ObjectPool<StringTable> pool = null;
+            ObjectPool<StringTable>? pool = null;
             pool = new ObjectPool<StringTable>(() => new StringTable(pool), Environment.ProcessorCount * 2);
             return pool;
         }
@@ -125,7 +127,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            string shared = FindSharedEntry(chars, start, len, hashCode);
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does elementwise assignment of a struct
@@ -159,7 +161,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            string shared = FindSharedEntry(chars, start, len, hashCode);
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does elementwise assignment of a struct
@@ -193,7 +195,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does elementwise assignment of a struct
@@ -227,7 +229,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does elementwise assignment of a struct
@@ -261,7 +263,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 // PERF: the following code does elementwise assignment of a struct
@@ -277,12 +279,12 @@ namespace Microsoft.Language.Xml
             return chars;
         }
 
-        private static string FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        private static string? FindSharedEntry(char[] chars, int start, int len, int hashCode)
         {
             var arr = sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -312,12 +314,12 @@ namespace Microsoft.Language.Xml
             return e;
         }
 
-        private static string FindSharedEntry(string chars, int start, int len, int hashCode)
+        private static string? FindSharedEntry(string chars, int start, int len, int hashCode)
         {
             var arr = sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -347,12 +349,12 @@ namespace Microsoft.Language.Xml
             return e;
         }
 
-        private static string FindSharedEntry(char chars, int hashCode)
+        private static string? FindSharedEntry(char chars, int hashCode)
         {
             var arr = sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -381,12 +383,12 @@ namespace Microsoft.Language.Xml
             return e;
         }
 
-        private static string FindSharedEntry(StringBuilder chars, int hashCode)
+        private static string? FindSharedEntry(StringBuilder chars, int hashCode)
         {
             var arr = sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -416,12 +418,12 @@ namespace Microsoft.Language.Xml
             return e;
         }
 
-        private static string FindSharedEntry(string chars, int hashCode)
+        private static string? FindSharedEntry(string chars, int hashCode)
         {
             var arr = sharedTable;
             int idx = SharedIdxFromHash(hashCode);
 
-            string e = null;
+            string? e = null;
             // we use quadratic probing here
             // bucket positions are (n^2 + n)/2 relative to the masked hashcode
             for (int i = 1; i < SharedBucketSize + 1; i++)
@@ -526,7 +528,7 @@ namespace Microsoft.Language.Xml
         {
             var hashCode = Hash.GetFNVHashCode(chars);
 
-            string shared = FindSharedEntry(chars, hashCode);
+            string? shared = FindSharedEntry(chars, hashCode);
             if (shared != null)
             {
                 return shared;

--- a/src/Microsoft.Language.Xml/Utilities/SyntaxLocator.cs
+++ b/src/Microsoft.Language.Xml/Utilities/SyntaxLocator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Language.Xml
         public static SyntaxNode FindNode(
             this SyntaxNode node,
             int position,
-            Func<SyntaxNode, bool> descendIntoChildren = null,
+            Func<SyntaxNode, bool>? descendIntoChildren = null,
             bool includeTrivia = true,
             bool excludeTerminal = false)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.Language.Xml
             public int i;
         }
 
-        public static IEnumerable<SyntaxNode> Tokens(this SyntaxNode root, TextSpan span, Func<SyntaxNode, bool> descendIntoChildren = null)
+        public static IEnumerable<SyntaxNode> Tokens(this SyntaxNode root, TextSpan span, Func<SyntaxNode, bool>? descendIntoChildren = null)
         {
             VisitState currentState = new VisitState() { node = root };
             Stack<VisitState> stateStack = new Stack<VisitState>();

--- a/src/Microsoft.Language.Xml/Utilities/SyntaxNodeCache.cs
+++ b/src/Microsoft.Language.Xml/Utilities/SyntaxNodeCache.cs
@@ -138,12 +138,12 @@ namespace Microsoft.Language.Xml
             }
         }
 
-        private static bool CanBeCached(GreenNode child1)
+        private static bool CanBeCached(GreenNode? child1)
         {
             return child1 == null || child1.IsCacheable;
         }
 
-        private static bool CanBeCached(GreenNode child1, GreenNode child2)
+        private static bool CanBeCached(GreenNode? child1, GreenNode child2)
         {
             return CanBeCached(child1) && CanBeCached(child2);
         }
@@ -153,7 +153,7 @@ namespace Microsoft.Language.Xml
             return CanBeCached(child1) && CanBeCached(child2) && CanBeCached(child3);
         }
 
-        private static bool ChildInCache(GreenNode child)
+        private static bool ChildInCache(GreenNode? child)
         {
             // for the purpose of this function consider that
             // null nodes, tokens and trivias are cached somewhere else.
@@ -171,7 +171,7 @@ namespace Microsoft.Language.Xml
             var cnt = node.SlotCount;
             for (int i = 0; i < cnt; i++)
             {
-                if (!ChildInCache((GreenNode)node.GetSlot(i)))
+                if (!ChildInCache((GreenNode?)node.GetSlot(i)))
                 {
                     return false;
                 }
@@ -180,12 +180,12 @@ namespace Microsoft.Language.Xml
             return true;
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode child1, out int hash)
         {
             return TryGetNode(kind, child1, GetDefaultNodeFlags(), out hash);
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, NodeFlags flags, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode child1, NodeFlags flags, out int hash)
         {
             if (CanBeCached(child1))
             {
@@ -208,12 +208,12 @@ namespace Microsoft.Language.Xml
             return null;
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode? child1, GreenNode child2, out int hash)
         {
             return TryGetNode(kind, child1, child2, GetDefaultNodeFlags(), out hash);
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, NodeFlags flags, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode? child1, GreenNode child2, NodeFlags flags, out int hash)
         {
             if (CanBeCached(child1, child2))
             {
@@ -236,12 +236,12 @@ namespace Microsoft.Language.Xml
             return null;
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, GreenNode child3, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, GreenNode child3, out int hash)
         {
             return TryGetNode(kind, child1, child2, child3, GetDefaultNodeFlags(), out hash);
         }
 
-        internal static GreenNode TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, GreenNode child3, NodeFlags flags, out int hash)
+        internal static GreenNode? TryGetNode(SyntaxKind kind, GreenNode child1, GreenNode child2, GreenNode child3, NodeFlags flags, out int hash)
         {
             if (CanBeCached(child1, child2, child3))
             {
@@ -279,7 +279,7 @@ namespace Microsoft.Language.Xml
             return code & Int32.MaxValue;
         }
 
-        private static int GetCacheHash(SyntaxKind kind, NodeFlags flags, GreenNode child1, GreenNode child2)
+        private static int GetCacheHash(SyntaxKind kind, NodeFlags flags, GreenNode? child1, GreenNode? child2)
         {
             int code = (int)(flags) ^ (int)kind;
 

--- a/src/Microsoft.Language.Xml/Utilities/TextKeyedCache.cs
+++ b/src/Microsoft.Language.Xml/Utilities/TextKeyedCache.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     internal class TextKeyedCache<T> where T : class
@@ -59,7 +61,7 @@ namespace Microsoft.Language.Xml
 
         // random - used for selecting a victim in the shared cache.
         // TODO: consider whether a counter is random enough
-        private Random _random;
+        private Random? _random;
 
         internal TextKeyedCache() :
             this(null)
@@ -69,18 +71,18 @@ namespace Microsoft.Language.Xml
         // implement Poolable object pattern
         #region "Poolable"
 
-        private TextKeyedCache(ObjectPool<TextKeyedCache<T>> pool)
+        private TextKeyedCache(ObjectPool<TextKeyedCache<T>>? pool)
         {
             _pool = pool;
             _strings = new StringTable();
         }
 
-        private readonly ObjectPool<TextKeyedCache<T>> _pool;
+        private readonly ObjectPool<TextKeyedCache<T>>? _pool;
         private static readonly ObjectPool<TextKeyedCache<T>> s_staticPool = CreatePool();
 
         private static ObjectPool<TextKeyedCache<T>> CreatePool()
         {
-            ObjectPool<TextKeyedCache<T>> pool = null;
+            ObjectPool<TextKeyedCache<T>>? pool = null;
             pool = new ObjectPool<TextKeyedCache<T>>(() => new TextKeyedCache<T>(pool), Environment.ProcessorCount * 4);
             return pool;
         }
@@ -101,7 +103,7 @@ namespace Microsoft.Language.Xml
 
         #endregion // Poolable
 
-        internal T FindItem(string chars, int start, int len, int hashCode)
+        internal T? FindItem(string chars, int start, int len, int hashCode)
         {
             // get direct element reference to avoid extra range checks
             ref var localSlot = ref _localTable[LocalIdxFromHash (hashCode)];
@@ -116,7 +118,7 @@ namespace Microsoft.Language.Xml
                 }
             }
 
-            SharedEntryValue e = FindSharedEntry(chars, start, len, hashCode);
+            SharedEntryValue? e = FindSharedEntry(chars, start, len, hashCode);
             if (e != null)
             {
                 // PERF: the following code does element-wise assignment of a struct
@@ -134,12 +136,12 @@ namespace Microsoft.Language.Xml
             return null;
         }
 
-        private SharedEntryValue FindSharedEntry(string chars, int start, int len, int hashCode)
+        private SharedEntryValue? FindSharedEntry(string chars, int start, int len, int hashCode)
         {
             var arr = _sharedTableInst;
             int idx = SharedIdxFromHash(hashCode);
 
-            SharedEntryValue e = null;
+            SharedEntryValue? e = null;
             int hash;
 
             // we use quadratic probing here

--- a/src/Microsoft.Language.Xml/XmlExtensions.cs
+++ b/src/Microsoft.Language.Xml/XmlExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+#pragma warning disable CS8602
+
 namespace Microsoft.Language.Xml
 {
     public static class XmlExtensions


### PR DESCRIPTION
Not sure if you'll want to accept this as it's a rather large change, but I wanted to see how difficult it would be ;)

The current state of the PR is an initial pass where I didn't try to change any logic or add any null-forgiving operators. As such there remain a number of nullable warnings which are currently suppressed with a `#pragma warning disable` in the containing file.

One thing I wasn't sure about was making parameters nullable in `SyntaxFactory`: the parser itself calls certain methods in here with `null` in order to represent invalid XML, but I'm not sure if the intention is to be able to create invalid XML from a `SyntaxFactory` or not (from what I can see Roslyn doesn't allow this).